### PR TITLE
Start, stop and restart conductr service

### DIFF
--- a/src/main/play-doc/intro/Manage-Services.md
+++ b/src/main/play-doc/intro/Manage-Services.md
@@ -1,0 +1,48 @@
+# Typesafe ConductR %PLAY_VERSION%
+
+
+## Manage ConductR Services
+
+During installation ConductR registers a new linux service `conductr`. If HAProxy is installed, the service `conductr-haproxy` is registered as well. Both services are started automatically during boot-up.
+
+### User
+The `conductr` service runs as the daemon user `conductr` in the daemon group `conductr`. When the service is started the first time it creates the user and group itself.
+
+The `conductr` user executes the commands in the background without any shell. You can specify additional environment variables in `/etc/default/conductr`. This file will be sourced before the actual service gets started.
+
+
+### Change Service State
+
+In order to start, stop or restart ConductR on one node simply change the state of the service. Each linux distribution uses different service managers:
+
+**systemd**
+
+```bash
+sudo systemctl conductr start
+sudo systemctl conductr stop
+sudo systemctl conductr restart
+```
+
+**sysvinit**
+
+```bash
+sudo service conductr start
+sudo service conductr stop
+sudo service conductr restart
+```
+
+
+#### Restart Cluster
+
+Restarting the entire ConductR cluster should only be considered in a face of disaster where all nodes have been lost. This restart need to be performed in a sequential order. This is necessary to ensure that at least one seed node is always up and running. Restarting all nodes at the same time will stop all nodes first. If now a node is starting again, it will not find any existing seed node and therefor it will register itself as a seed node in a new cluster. This means that each node starting in parallel will form its own cluster. To avoid this scenario restart the `conductr` service first on one node. If the service has been restarted successfully continue with the next node and repeat that until all services has been restarted.
+
+**Troubleshooting**
+In case a node has accidentally formed its own cluster you can stop this node and remove the seed node information. Afterwards start this node again.
+
+```bash
+sudo systemctl conductr stop
+sudo rm /usr/share/conductr/conf/seed-nodes
+sudo systemctl conductr start
+```
+
+During startup the node will now join another running cluster as a cluster member.

--- a/src/main/play-doc/intro/index.toc
+++ b/src/main/play-doc/intro/index.toc
@@ -2,3 +2,4 @@ Intro:Introducing ConductR
 Install:Installation
 Install-EC2:Installation using EC2
 Quickstart:Quickstart
+Manage-Services:Manage ConductR Services 


### PR DESCRIPTION
Added documentation how manage the conductr and conductr-haproxy service. Also explained how to restart conductr sequiantially in order to avoid split brain scenarios.

This documentation references to the issue: https://github.com/typesafehub/conductr/issues/651
