### PR TITLE
Only set the 'hostname' will not survive the next restart and the nod…

### DIFF
--- a/src/main/play-doc/gettingStarted/Install.md
+++ b/src/main/play-doc/gettingStarted/Install.md
@@ -48,7 +48,7 @@ echo "JAVA_HOME=/usr/lib/jvm/java-8-oracle" | sudo tee -a /etc/environment
 This tutorial uses three systems with the addresses `172.17.0.{1,2,3}`. To simplify the installation and configuration instructions, we are going to use the hostname command. Please ensure the hostname is set correctly or substitute your addresses as appropriate for $(hostname). To set the hostname, pass the ip address to hostname.
 
 ```bash
-sudo hostname $(hostname -i)
+sudo hostnamectl set-hostname [ipAddress]
 ```
 
 The tutorial also assumes that you have obtained the `conductr_%PLAY_VERSION%_all.deb` Debian or `conductr_%PLAY_VERSION%-1.noarch.rpm` Rpm package.


### PR DESCRIPTION
…e can't connect to the cluster.

hostnamectl set the hostname permanently.
