### PR TITLE
Add bundle restart documentation

### DIFF
--- a/src/main/play-doc/operation/ClusterTroubleshooting.md
+++ b/src/main/play-doc/operation/ClusterTroubleshooting.md
@@ -1,5 +1,7 @@
 # Cluster Troubleshooting
 
+## Cluster Split Recovery
+
 Cluster partition is a failure that may occur when running a cluster based application. To recover from this situation ConductR utilizes Akka SBR (Split Brain Recovery). Akka SBR is a part of Akka in the [Typesafe Reactive Platform](http://www.typesafe.com/products/typesafe-reactive-platform) version `15v01p05`.
 
 The Akka SBR strategy adopted by ConductR is `keep-majority`.
@@ -8,8 +10,6 @@ The `keep-majority` strategy ensures when cluster split occurs:
 
 * The partition which has the majority of the nodes are kept running
 * Other partition(s) which has less than majority of the nodes will have their ConductR process terminated.
-
-## Cluster Split Recovery
 
 Upon cluster split, Akka SBR will terminate the ConductR processes within the partition that does not have majority number of nodes.
 
@@ -85,3 +85,24 @@ sudo service conductr restart
 * Upon restart, this node will attempt to reconnect to last known members of the cluster based on the information stored in the `seed-nodes` file. The node will persist with the reconnection attempt until they are successful.
 
 * If the service has been restarted successfully continue with the next node and repeat that until all services has been restarted.
+
+
+## Restarting Bundles
+
+### Cluster node termination
+
+If a bundle dies due to a shutdown or crash of the `conductr` service on a node the bundle will be automatically started on a different node within the ConductR cluster.
+   
+**Example**
+
+1. An application bundle gets loaded on a 3-node ConductR cluster. By default the bundle will be replicated to all 3 nodes.
+2. We run the bundle on 2 nodes. ConductR decided to start the bundles on node 1 and 2.
+3. Node 1, on which the bundle is running, goes down.
+4. ConductR identifies this change and automatically starts the bundle on the remaining node 3 to keep the scaling factor of 2.
+5. When bringing back node 1 the bundle is automatically loaded to this node, but not started. The scaling factor is kept to 2. The bundles are still running on node 2 and 3.
+
+The application state is not automatically restored by ConductR. When deploying a stateful bundle ensure in your application that the state is getting replicated, e.g. with [Akka Distributed Data](http://doc.akka.io/docs/akka/snapshot/scala/distributed-data.html), [Akka Cluster Sharding](http://doc.akka.io/docs/akka/snapshot/scala/cluster-sharding.html) and [Persistence](http://doc.akka.io/docs/akka/snapshot/scala/persistence.html) or distributed databases. 
+     
+### Bundle termination 
+    
+If a bundle dies of its own accord then ConductR does not attempt to restart it. The reason is that it doesn't really know why it has stopped, it could be for a legitimate reason e.g. a short lived task.


### PR DESCRIPTION
PR is adding bundle restart documentation, which has been requested with issue #31. 

New sub-chapter has been added to the section https://github.com/typesafehub/conductr-doc/blob/master/src/main/play-doc/operation/ClusterTroubleshooting.md
