### PR TITLE
Fix Control API doc

### DIFF
--- a/src/main/play-doc/api/BundleAPI.md
+++ b/src/main/play-doc/api/BundleAPI.md
@@ -8,8 +8,8 @@ The [ConductR bundle library](https://github.com/typesafehub/conductr-bundle-lib
 
 Two services are covered by the bundle API:
 
-* [Location lookup service](#the-location-lookup-service)
-* [Status service](#the-status-service)
+* [Location lookup service](#The-Location-Lookup-Service)
+* [Status service](#The-Status-Service)
 
 ## The Location Lookup Service
 

--- a/src/main/play-doc/api/ControlAPI.md
+++ b/src/main/play-doc/api/ControlAPI.md
@@ -36,11 +36,12 @@ The following fields are provided as multipart/form-data fields:
 
 Field            | Description
 -----------------|------------
-system           | As per its equivalent property in [bundle.conf](Bundles.html)
-bundleName       | As per its equivalent property in [bundle.conf](Bundles.html)
-nrOfCpus         | As per its equivalent property in [bundle.conf](Bundles.html)
-memory           | As per its equivalent property in [bundle.conf](Bundles.html)
-roles            | As per its equivalent property in [bundle.conf](Bundles.html)
+system           | As per its equivalent property in [bundle.conf](BundleConfiguration)
+bundleName       | As per its equivalent property in [bundle.conf](BundleConfiguration)
+nrOfCpus         | As per its equivalent property in [bundle.conf](BundleConfiguration)
+memory           | As per its equivalent property in [bundle.conf](BundleConfiguration)
+diskSpace        | As per its equivalent property in [bundle.conf](BundleConfiguration)
+roles            | As per its equivalent property in [bundle.conf](BundleConfiguration)
 bundle           | The file that is the bundle. The filename is important with its hex digest string and is required to be consistent with the SHA-256 hash of the bundle's contents. Any inconsistency between the hashes will result in the load being rejected.
 configuration    | Optional. Similar in form to the bundle, only that is the file that describes the configuration. Again any inconsistency between the hex digest string in the filename, and the SHA-256 digest of the actual contents will result in the load being rejected.
 


### PR DESCRIPTION
- Adds `diskSpace` description to [Load Bundle API](http://localhost:9000/docs/1.0.x/ControlAPI#Load-a-bundle)
- Fixes links in [Load Bundle API](http://localhost:9000/docs/1.0.x/BundleAPI) to `bundle.conf`
- Fixes toc links in [Bundle API](http://localhost:9000/docs/1.0.x/BundleAPI)
