### PR TITLE
Update sbt-conductr-sandbox version to 1.0.5

### DIFF
--- a/src/main/play-doc/developer/ConductrSandbox.md
+++ b/src/main/play-doc/developer/ConductrSandbox.md
@@ -13,7 +13,7 @@ The following description is intended to provide a taste of what `sbt-conductr-s
 1. Add the sbt plugin to the `project/plugins.sbt` of your project:
 
     ```scala
-    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.0.4")
+    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.0.5")
     ```
 2. Enable the sbt plugin in the `build.sbt`:    
 

--- a/src/main/play-doc/developer/DevQuickStart.md
+++ b/src/main/play-doc/developer/DevQuickStart.md
@@ -90,7 +90,7 @@ In order to manage a ConductR cluster we provide a sbt plugin [sbt-conductr-sand
 1. Add the sbt plugin to the `project/plugins.sbt` of your project:
 
     ```scala
-    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.0.4")
+    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.0.5")
     ```
 2. Enable the sbt plugin in the `build.sbt`:    
 

--- a/src/main/play-doc/developer/ResolvingServices.md
+++ b/src/main/play-doc/developer/ResolvingServices.md
@@ -5,7 +5,9 @@ When you create a bundle you can declare service names to ConductR. You can reso
 Firstly establish the URL for locating the accounts service. Note that your code should look toward factoring out this type of behavior so that you do not hard-code host addresses or ports. For this example though, we'll relax that recommendation for the sake of clarity:
 
 ```Scala
-val accounts = LocationService.getLookupUrl("/accounts", "http://127.0.0.1:9000/accounts")
+import com.typesafe.conductr.bundlelib.scala.URL
+
+val accounts = LocationService.getLookupUrl("/accounts", URL("http://127.0.0.1:9000/accounts")
 ```
 
 If the above code is run with your component has been started by ConductR then the `accounts` value will contain a URL to ConductR's service locator. Otherwise, when not running via ConductR then a service running on the loopback interface will be used; this latter one being something generally useful to you when in development mode, or an address for when running your component outside of ConductR.


### PR DESCRIPTION
- Update sbt-conductr-sandbox version to 1.0.5
- Use `URL` instead of `String` in `LocationService.getLookupUrl`
