### PR TITLE
Update sbt-conductr-sandbox to 1.1.0

### DIFF
--- a/src/main/play-doc/developer/ConductrSandbox.md
+++ b/src/main/play-doc/developer/ConductrSandbox.md
@@ -13,7 +13,7 @@ The following description is intended to provide a taste of what `sbt-conductr-s
 Add the sbt plugin to the `project/plugins.sbt` of your project:
 
 ```scala
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.0.7")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.1.0")
 ```
 
 The plugin is then enabled automatically for your entire project.

--- a/src/main/play-doc/developer/DevQuickStart.md
+++ b/src/main/play-doc/developer/DevQuickStart.md
@@ -90,7 +90,7 @@ In order to manage a ConductR cluster we provide a sbt plugin [sbt-conductr-sand
 1. Add the sbt plugin to the `project/plugins.sbt` of your project (the plugin is automatically enabled):
 
     ```scala
-    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.0.7")
+    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.1.0")
     ```
 2. Reload the sbt session:
 


### PR DESCRIPTION
Update `sbt-conductr-sandbox` from 1.0.7 to 1.1.0. This version should only be used in ConductR 1.1.x and above. ConductR 1.0.x should use 1.0.7.
