### PR TITLE
Update sbt plugin versions

### DIFF
--- a/src/main/play-doc/developer/ConductrSandbox.md
+++ b/src/main/play-doc/developer/ConductrSandbox.md
@@ -4,19 +4,30 @@ A Developer Sandbox Docker image is available so that developers can validate an
 
 The ConductR Developer Sandbox is available to freely all developers. To request access to the sandbox, login to Typesafe.com to visit the [ConductR Developer page](https://www.typesafe.com/product/conductr/developer).
 
-> The Docker image `sbt-conductr-sandbox` is using contains a single node version of ConductR. It is not recommended to use this version in production.
+> The Docker image of `sbt-conductr-sandbox` contains the single node version of ConductR. It is not recommended to use this version in production.
 
 The following description is intended to provide a taste of what `sbt-conductr-sandbox` can do for you. Please refer to [its documentation](https://github.com/typesafehub/sbt-conductr-sandbox) for more details.
 
 ## Setting up sbt-conductr-sandbox
 
-Add the sbt plugin to the `project/plugins.sbt` of your project:
+1. Add the sbt plugin to the `project/plugins.sbt` of your project:
 
-```scala
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.0.7")
-```
+    ```scala
+    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.1.2")
+    ```
+2. Add the ConductR image version to the `build.sbt`:    
 
-The plugin is then enabled automatically for your entire project.
+    ```scala
+    SandboxKeys.imageVersion in Global := "1.0.11"
+    ```
+
+3. Reload the sbt session:
+
+    ```scala
+    reload
+    ```    
+
+The plugin is then enabled automatically for your entire project. Additionally it includes `sbt-conductr` and `sbt-bundle` so these plugins doesn't need to be added separately. The `conduct` commands such as `conduct info` will automatically communicate with the Docker cluster managed by the sandbox. There is no need to set ConductR's ip address with `controlServer` manually.
 
 ## Using sbt-conductr-sandbox
 
@@ -54,7 +65,7 @@ The `visualization` feature provides a web interface to visualize the ConductR c
 
 [[images/visualizer_simple.png]]
 
-The `logging` feature consolidates the logging output of ConductR itself and the bundles that it executes. To view the consolidated log messsages enable [sbt-conductr](https://github.com/sbt/sbt-conductr) and then run:
+The `logging` feature consolidates the logging output of ConductR itself and the bundles that it executes. To view the consolidated log messsages run:
 
 ```scala
 conduct logs conductr-elasticsearch
@@ -120,7 +131,3 @@ To stop the ConductR sandbox use:
 ```scala
 sandbox stop
 ```
-
-### Using sbt-conductr-sandbox with sbt-conductr
-
-If the `sbt-conductr` plugin is added to your project then the `conduct` commands such as `conduct info` will automatically communicate with the Docker cluster managed by the sandbox. There is no need to set ConductR's ip address with `controlServer` manually.

--- a/src/main/play-doc/developer/DeployingBundles.md
+++ b/src/main/play-doc/developer/DeployingBundles.md
@@ -7,10 +7,10 @@ The following description is intended to provide a taste of what `sbt-conductr` 
 To use `sbt-conductr` first add the plugin your build (typically your `project/plugins.sbt` file); be sure to check at [the plugin's website](https://github.com/sbt/sbt-conductr#sbt-conductr) for the latest version to use:
 
 ```scala
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.1")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.1.1")
 ```
 
-> If you add this plugin as above, you do not need to have an explicit declaration for `sbt-bundle`. `sbt-bundle` will be automatically added as a dependency of `sbt-conductr`.
+> If you add this plugin as above, you do not need to have an explicit declaration for `sbt-bundle`. `sbt-bundle` will be automatically added as a dependency of `sbt-conductr`. If you have already added `sbt-conductr-sandbox` as an sbt plugin before then `sbt-conductr` doesn't need to be added as well. `sbt-conductr` will be automatically added as a dependency of `sbt-conductr-sandbox`.
 
 The `sbt-bundle` plugin must then be enabled for your project. Supposing that your project has one module that will use the plugin which is the root of the sbt project (the most typical situation for a single `build.sbt`):
 
@@ -53,6 +53,6 @@ You can also run, stop and unload bundles by using this plugin. This may be usef
 
 > The host running sbt in this example must have access to the ConductR daemon ports. Please see  [[Cluster security considerations|ClusterSetupConsiderations#Cluster-security-considerations]] for further information on controlling cluster access.
 
-That is all that is required in essence, but as stated, you should read [`sbt-conductr`'s documentation](https://github.com/sbt/sbt-conductr/blob/master/README.md) as there are a few additional requirements, particularly if you are managing a Play 2.3 application.
+That is all that is required in essence, but as stated, you should read the [documentation](https://github.com/sbt/sbt-conductr/blob/master/README.md) of `sbt-conductr` as there are a few additional requirements, particularly if you are managing a Play 2.3 application.
 
 Now go and develop reactive applications or services for ConductR!

--- a/src/main/play-doc/developer/DevQuickStart.md
+++ b/src/main/play-doc/developer/DevQuickStart.md
@@ -38,12 +38,12 @@ play.modules.enabled += "com.typesafe.conductr.bundlelib.play.ConductRLifecycleM
 
 ## Creating application bundle
 
-[sbt-conductr](https://github.com/sbt/sbt-conductr) is an sbt plugin to easily manage your application bundle inside ConductR. This plugin includes [sbt-bundle](https://github.com/sbt/sbt-bundle#typesafe-conductr-bundle-plugin) which we will use to create the application bundle for our Play application. 
+[sbt-conductr-sandbox](https://github.com/typesafehub/sbt-conductr-sandbox) is an sbt plugin to easily manage your application inside ConductR. This plugin includes [sbt-bundle](https://github.com/sbt/sbt-bundle#typesafe-conductr-bundle-plugin) and [sbt-conductr](https://github.com/sbt/sbt-conductr).
 
-1. Add `sbt-conductr` to the `project/plugins.sbt`:
+1. Add `sbt-conductr-sandbox` to the `project/plugins.sbt`:
 
     ```scala
-    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.1")
+    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.1.2")
     ```
 2. Specify `sbt-bundle` keys in the `build.sbt`:   
 
@@ -73,15 +73,9 @@ As you move through our documentation you will  come across references to Conduc
 
 ## Starting ConductR cluster
 
-In order to manage a ConductR cluster we provide a sbt plugin [sbt-conductr-sandbox](https://github.com/typesafehub/sbt-conductr-sandbox). Follow these steps to start the ConductR cluster.
+Now we can go ahead an start the ConductR cluster locally.
 
-
-1. Add the sbt plugin to the `project/plugins.sbt` of your project (the plugin is automatically enabled):
-
-    ```scala
-    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.0.7")
-    ```
-2. Add the ConductR image version to the `build.sbt`:
+1. Add the ConductR image version to the `build.sbt`:
 
     ```scala
     SandboxKeys.imageVersion in Global := "1.0.11"


### PR DESCRIPTION
Updates the sbt plugin versions to:
- sbt-conductr 1.1.1
- sbt-conductr-sandbox 1.1.2

Also applies the documentation changes from PR https://github.com/typesafehub/conductr-doc/pull/105/files.
