### PR TITLE
Update Logging documentation - showing debug level log messages from all library

### DIFF
--- a/src/main/play-doc/operation/Logging.md
+++ b/src/main/play-doc/operation/Logging.md
@@ -220,7 +220,7 @@ To view all `debug` level log messages, configure ConductR as:
 
 ``` bash
 echo \
-  -Dakka.logging-filter=akka.event.DefaultLoggingFilter \
+  -Droot.loglevel=debug \
   -Dakka.loglevel=debug | \
   sudo tee -a /usr/share/conductr/conf/application.ini
 sudo /etc/init.d/conductr restart


### PR DESCRIPTION
Use `-Droot.loglevel=debug` to enable debug from all libraries use by ConductR

**Important**: Merge only after 1.1 with RP version `16s01p01` is released
