### PR TITLE
Update conductr-lib instructions

### DIFF
--- a/src/main/play-doc/developer/DevQuickStart.md
+++ b/src/main/play-doc/developer/DevQuickStart.md
@@ -32,14 +32,13 @@ First let us setup the Play 2.4 application for ConductR. Your application shoul
 ```scala
 resolvers += "typesafe-releases" at "http://repo.typesafe.com/typesafe/maven-releases"
 
-libraryDependencies += "com.typesafe.conductr" %% "play24-conductr-bundle-lib" % "1.2.0"
+libraryDependencies += "com.typesafe.conductr" %% "play24-conductr-bundle-lib" % "1.3.0"
 ```
 
 Now you can add a guice module in the `application.conf`. This module tells ConductR when your application has been started and therefore ready to start processing requests:
 
 ```scala
 play.application.loader = "com.typesafe.conductr.bundlelib.play.ConductRApplicationLoader"
-play.modules.enabled += "com.typesafe.conductr.bundlelib.play.ConductRLifecycleModule"
 ```
 
 ## Creating application bundle

--- a/src/main/play-doc/developer/SignalingApplicationState.md
+++ b/src/main/play-doc/developer/SignalingApplicationState.md
@@ -18,7 +18,7 @@ To use it add one of the libraries as a dependency to your `build.sbt`:
 ```scala
 resolvers += "typesafe-releases" at "http://repo.lightbend.com/typesafe/maven-releases"
 
-libraryDependencies += "com.typesafe.conductr" %% "scala-conductr-bundle-lib" % "1.2.0"
+libraryDependencies += "com.typesafe.conductr" %% "scala-conductr-bundle-lib" % "1.3.0"
 ```
 
 The Java and Scala / JDK library have no dependencies other than the JDK and as such, a blocking implementation is used for its HTTP calls (the JDK offers no non-blocking APIs for this). Using the Akka or Play library will ensure that the library is consistent with the respective Akka or Play application and that non-blocking implementations are used:


### PR DESCRIPTION
- Updating conductr-lib version to 1.3
- Changing Play 2.4 instructions. The module `com.typesafe.conductr.bundlelib.play.ConductRLifecycleModule` doesn't need to be enabled anymore
