### PR TITLE
Update plugin versions

### DIFF
--- a/src/main/play-doc/developer/ConductrSandbox.md
+++ b/src/main/play-doc/developer/ConductrSandbox.md
@@ -10,12 +10,21 @@ The ConductR Developer Sandbox is available to freely all developers. To request
 
 The following description is intended to provide a taste of what `sbt-conductr-sandbox` can do for you. Please refer to [its documentation](https://github.com/typesafehub/sbt-conductr-sandbox) for more details.
 
+## Prerequisites
+
+* [Docker](https://www.docker.com/)
+* [conductr-cli](CLI)
+
+Docker is required so that you can run the ConductR cluster as if it were running on a number of machines in your network. You won't need to understand much about Docker for ConductR other than installing it as described in its "Get Started" section. If you are on Windows or Mac then you will become familiar with `docker-machine` which is a utility that controls a virtual machine for the purposes of running Docker.
+
+The conductr-cli is used to communicate with the ConductR cluster.
+
 ## Setting up sbt-conductr-sandbox
 
 1. Add the sbt plugin to the `project/plugins.sbt` of your project:
 
     ```scala
-    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.2.2")
+    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.4.0")
     ```
 2. Specify the ConductR Developer Sandbox version in the `build.sbt`.Please visit the [ConductR Developer page](http://www.lightbend.com/product/conductr/developer) to retrieve the current version:
 

--- a/src/main/play-doc/developer/DeployingBundles.md
+++ b/src/main/play-doc/developer/DeployingBundles.md
@@ -7,7 +7,7 @@ The following description is intended to provide a taste of what `sbt-conductr` 
 To use `sbt-conductr` first add the plugin your build (typically your `project/plugins.sbt` file); be sure to check at [the plugin's website](https://github.com/sbt/sbt-conductr#sbt-conductr) for the latest version to use:
 
 ```scala
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.2.0")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.5.0")
 ```
 
 > If you add this plugin as above, you do not need to have an explicit declaration for `sbt-bundle`. `sbt-bundle` will be automatically added as a dependency of `sbt-conductr`. If you have already added `sbt-conductr-sandbox` as an sbt plugin before then `sbt-conductr` doesn't need to be added as well. `sbt-conductr` will be automatically added as a dependency of `sbt-conductr-sandbox`.

--- a/src/main/play-doc/developer/DevQuickStart.md
+++ b/src/main/play-doc/developer/DevQuickStart.md
@@ -20,10 +20,13 @@ The focus of this section is to get started quickly. The full documentation of t
 
 * [Docker](https://www.docker.com/)
 * [sbt](http://www.scala-sbt.org/download.html)
+* [conductr-cli](CLI)
 
 Docker is required so that you can run the ConductR cluster as if it were running on a number of machines in your network. You won't need to understand much about Docker for ConductR other than installing it as described in its "Get Started" section. If you are on Windows or Mac then you will become familiar with `docker-machine` which is a utility that controls a virtual machine for the purposes of running Docker.
 
 sbt is our interactive build tool. Reading the getting started guide for sbt is recommended.
+
+The conductr-cli is used to communicate with the ConductR cluster.
 
 ## Signaling application state
 
@@ -32,7 +35,7 @@ First let us setup the Play 2.4 application for ConductR. Your application shoul
 ```scala
 resolvers += "typesafe-releases" at "http://repo.typesafe.com/typesafe/maven-releases"
 
-libraryDependencies += "com.typesafe.conductr" %% "play24-conductr-bundle-lib" % "1.3.0"
+libraryDependencies += "com.typesafe.conductr" %% "play24-conductr-bundle-lib" % "1.4.0"
 ```
 
 Now you can add a guice module in the `application.conf`. This module tells ConductR when your application has been started and therefore ready to start processing requests:
@@ -48,7 +51,7 @@ play.application.loader = "com.typesafe.conductr.bundlelib.play.ConductRApplicat
 1. Add `sbt-conductr-sandbox` to the `project/plugins.sbt`:
 
     ```scala
-    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.2.2")
+    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.4.0")
     ```
 2. Specify `sbt-bundle` keys in the `build.sbt`:   
 

--- a/src/main/play-doc/developer/SignalingApplicationState.md
+++ b/src/main/play-doc/developer/SignalingApplicationState.md
@@ -18,7 +18,7 @@ To use it add one of the libraries as a dependency to your `build.sbt`:
 ```scala
 resolvers += "typesafe-releases" at "http://repo.lightbend.com/typesafe/maven-releases"
 
-libraryDependencies += "com.typesafe.conductr" %% "scala-conductr-bundle-lib" % "1.3.0"
+libraryDependencies += "com.typesafe.conductr" %% "scala-conductr-bundle-lib" % "1.4.0"
 ```
 
 The Java and Scala / JDK library have no dependencies other than the JDK and as such, a blocking implementation is used for its HTTP calls (the JDK offers no non-blocking APIs for this). Using the Akka or Play library will ensure that the library is consistent with the respective Akka or Play application and that non-blocking implementations are used:


### PR DESCRIPTION
Update the following versions:
- sbt-conductr to 1.5.0
- sbt-conductr-sandbox to 1.4.0
- conductr-lib to 1.4.0

Updates for branch 1.1. Master PR is https://github.com/typesafehub/conductr-doc/pull/181.
