### PR TITLE
Bump conductr-bundle-lib to 1.4.1

### DIFF
--- a/src/main/play-doc/developer/DevQuickStart.md
+++ b/src/main/play-doc/developer/DevQuickStart.md
@@ -35,7 +35,7 @@ First let us setup the Play 2.4 application for ConductR. Your application shoul
 ```scala
 resolvers += "typesafe-releases" at "http://repo.typesafe.com/typesafe/maven-releases"
 
-libraryDependencies += "com.typesafe.conductr" %% "play24-conductr-bundle-lib" % "1.4.0"
+libraryDependencies += "com.typesafe.conductr" %% "play24-conductr-bundle-lib" % "1.4.1"
 ```
 
 Now you can add a guice module in the `application.conf`. This module tells ConductR when your application has been started and therefore ready to start processing requests:

--- a/src/main/play-doc/developer/SignalingApplicationState.md
+++ b/src/main/play-doc/developer/SignalingApplicationState.md
@@ -18,7 +18,7 @@ To use it add one of the libraries as a dependency to your `build.sbt`:
 ```scala
 resolvers += "typesafe-releases" at "http://repo.lightbend.com/typesafe/maven-releases"
 
-libraryDependencies += "com.typesafe.conductr" %% "scala-conductr-bundle-lib" % "1.4.0"
+libraryDependencies += "com.typesafe.conductr" %% "scala-conductr-bundle-lib" % "1.4.1"
 ```
 
 The Java and Scala / JDK library have no dependencies other than the JDK and as such, a blocking implementation is used for its HTTP calls (the JDK offers no non-blocking APIs for this). Using the Akka or Play library will ensure that the library is consistent with the respective Akka or Play application and that non-blocking implementations are used:


### PR DESCRIPTION
This is the PR for branch 1.1. Related master PR is https://github.com/typesafehub/conductr-doc/pull/191.
