### PR TITLE
Change dev guide based on sbt-conductr 2.0.1

### DIFF
--- a/src/main/play-doc/api/BundleAPI.md
+++ b/src/main/play-doc/api/BundleAPI.md
@@ -4,7 +4,7 @@
 ## The Bundle API
 
 
-The [ConductR bundle library](https://github.com/typesafehub/conductr-bundle-lib#typesafe-conductr-bundle-library) provides a convenient Scala, Akka and Play API over an underlying REST API. This document details the underlying REST API.
+The [ConductR bundle library](https://github.com/typesafehub/conductr-lib#typesafe-conductr-bundle-library) provides a convenient Scala, Akka and Play API over an underlying REST API. This document details the underlying REST API.
 
 The following services are covered by the bundle API:
 

--- a/src/main/play-doc/developer/AkkaAndPlay.md
+++ b/src/main/play-doc/developer/AkkaAndPlay.md
@@ -1,6 +1,6 @@
-# Akka and Play Specifics
+# Bundle library flavors
 
-[conductr-bundle-lib](https://github.com/typesafehub/conductr-bundle-lib#typesafe-conductr-bundle-library) comes in multiple flavors depending on whether you need it for Akka and/or Play development, and also the specific versions of Akka and Play. The libraries are structured as follows in this regard:
+The [ConductR bundle library](https://github.com/typesafehub/conductr-lib#typesafe-conductr-bundle-library) comes in multiple flavors depending on whether you need it for Lagom, Play or Akka development. It also supports different framework versions. The following flavors are supported by the library:
 
 * Akka 2.4 for Java and Scala - [akka24-conductr-bundle-lib](#akka23|24-conductr-bundle-lib)
 * Akka 2.3 for Java and Scala - [akka23-conductr-bundle-lib](#akka23|24-conductr-bundle-lib)
@@ -11,7 +11,7 @@
 
 ## akka[23|24]-conductr-bundle-lib
 
-Please select the Akka 2.3 or 2.4 variant depending on whether you are using Akka 2.3 or Play 2.4 respectively.
+Please select the Akka 2.3 or 2.4 variant depending on whether you are using Akka 2.3 or Akka 2.4 respectively.
 
 This library provides a reactive API using [Akka Http](http://akka.io/docs/) and should be used when you are using Akka. The library can be used for both Java and Scala.
 
@@ -123,6 +123,8 @@ In the above, no declaration of `services` is required as akka remoting is an in
 
 > If you are using Play 2.5 then this section is for you. Otherwise jump below to the [play[23|24]-conductr-bundle-lib](#play23|24-conductr-bundle-lib) section.
 
+[sbt-conductr](https://github.com/typesafehub/sbt-conductr) is automatically adding this library to your Play project.
+
 This library provides a reactive API using [Play WS](https://www.playframework.com/documentation/2.5.x/ScalaWS) and should be used when you are using Play. The library depends on `akka24-conductr-bundle-lib` and can be used for both Java and Scala. As per Play's conventions, `play.api` is used for the Scala API and just `play` is used for Java.
 
 As with `conductr-bundle-lib` there are two services:
@@ -151,14 +153,6 @@ The following components are available for injection:
 * LocationService
 * StatusService
 
-Note that your `application.conf` should contain the following (for Scala):
-
-```
-play.application.loader = "com.typesafe.conductr.bundlelib.play.lib.ConductRApplicationLoader"
-```
-
-For Java, just change the `play.api` to `play` in the above.
-
 Note that if you are using your own application loader then you should ensure that the Akka and Play ConductR-related properties are loaded. Here's a complete implementation (for Scala):
 
 ```scala
@@ -167,12 +161,15 @@ class MyCustomApplicationLoader extends ApplicationLoader {
     val conductRConfig = Configuration(AkkaEnv.asConfig) ++ Configuration(PlayEnv.asConfig)
     val newConfig = context.initialConfiguration ++ conductRConfig
     val newContext = context.copy(initialConfiguration = newConfig)
-    (new GuiceApplicationLoader).load(newContext)
+    val prodEnv = Environment.simple(mode = Mode.Prod)
+    (new GuiceApplicationLoader(new GuiceApplicationBuilder(environment = prodEnv))).load(newContext)
   }
 }
 ```
 
 ## play[23|24]-conductr-bundle-lib
+
+[sbt-conductr](https://github.com/typesafehub/sbt-conductr) is automatically adding this library to your Play project.
 
 Please select the Play 2.3 or 2.4 variant depending on whether you are using Play 2.3 or Play 2.4 respectively. Bringing in this library automatically brings in Akka 2.3.
 
@@ -227,12 +224,6 @@ In order for an application or service to take advantage of setting important Ak
 
 #### Play 2.4
 
-Your `application.conf` should contain the following:
-
-```
-play.application.loader = "com.typesafe.conductr.bundlelib.play.ConductRApplicationLoader"
-```
-
 Note that if you are using your own application loader then you should ensure that the Akka and Play ConductR-related properties are loaded. Here's a complete implementation:
 
 ```scala
@@ -267,3 +258,22 @@ object Global extends GlobalSettings {
 }
 ```
 
+## lagom10-conductr-bundle-lib
+
+> If you are using Lagom 1.0.x then this section is for you.
+
+[sbt-conductr](https://github.com/typesafehub/sbt-conductr) is automatically adding this library to your Lagom project. You don't need set any additional setting for your Lagom services.
+
+Note that if you are using your own application loader then you should ensure that the Akka, Play and Lagom ConductR-related properties are loaded. Here's a complete implementation (in Scala):
+
+```java
+class MyCustomApplicationLoader extends ApplicationLoader {
+  def load(context: ApplicationLoader.Context): Application = {
+    val conductRConfig = Configuration(AkkaEnv.asConfig) ++ Configuration(PlayEnv.asConfig) ++ Configuration(LagomEnv.asConfig)
+    val newConfig = context.initialConfiguration ++ conductRConfig
+    val newContext = context.copy(initialConfiguration = newConfig)
+    val prodEnv = Environment.simple(mode = Mode.Prod)
+    (new GuiceApplicationLoader(new GuiceApplicationBuilder(environment = prodEnv))).load(newContext)
+  }
+}
+```

--- a/src/main/play-doc/developer/ConductrSandbox.md
+++ b/src/main/play-doc/developer/ConductrSandbox.md
@@ -1,72 +1,31 @@
-# Advanced sbt sandbox
+# Managing ConductR sandbox cluster
 
-> Note that the ConductR sandbox is available as both an sbt plugin, and also as a command line tool. This document describes the sbt plugin variant and its position in terms of your development activities.
+sbt-conductr is using the ConductR sandbox image to spin up a local ConductR cluster. This is a docker image based on Ubuntu that includes ConductR which makes it simple to use ConductR in a development context. It can be also utilized by Continuous Integration (CI) and other automation to validate bundles within a cluster context. The sandbox is available to freely all developers.
 
-A Developer Sandbox Docker image is available so that developers can validate and debug ConductR applications without needing to run a full multi-node cluster. The sbt plugin [sbt-conductr-sandbox](https://github.com/typesafehub/sbt-conductr-sandbox) is using this Docker image and can be utilized locally by developers as well as by Continous Integration (CI) and other automation to validate bundles within a cluster context.
+> The docker image contains the full version of ConductR. However, it is not recommended to use this version in production because it is pre-configured for non production scenarios and because this ConductR version is started inside a Docker container.
 
-The ConductR Developer Sandbox is available to freely all developers. To request access to the sandbox, login to lightbend.com to visit the [ConductR Developer page](https://www.lightbend.com/product/conductr/developer).
+## Starting ConductR
 
-> The Docker image of `sbt-conductr-sandbox` contains the full version of ConductR. However, it is not recommended to use this version in production because it is pre-configured for non production scenarios and because this ConductR version is started inside a Docker container.
+The `sandbox run` command starts a local ConductR cluster. In order to use this command you need to specify the ConductR version. Note that this version is the version of ConductR itself and not the version of the `sbt-conductr` plugin. Please visit the [ConductR Developer page](https://www.lightbend.com/product/conductr/developer) to pick up the latest ConductR version from the section **Quick Configuration**.
 
-The following description is intended to provide a taste of what `sbt-conductr-sandbox` can do for you. Please refer to [its documentation](https://github.com/typesafehub/sbt-conductr-sandbox) for more details.
-
-## Prerequisites
-
-* [Docker](https://www.docker.com/)
-* [conductr-cli](CLI)
-
-Docker is required so that you can run the ConductR cluster as if it were running on a number of machines in your network. You won't need to understand much about Docker for ConductR other than installing it as described in its "Get Started" section. If you are on Windows or Mac then you will become familiar with `docker-machine` which is a utility that controls a virtual machine for the purposes of running Docker.
-
-The conductr-cli is used to communicate with the ConductR cluster.
-
-## Setting up sbt-conductr-sandbox
-
-1. Add the sbt plugin to the `project/plugins.sbt` of your project:
-
-    ```scala
-    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.4.1")
-    ```
-2. Specify the ConductR Developer Sandbox version in the `build.sbt`.Please visit the [ConductR Developer page](http://www.lightbend.com/product/conductr/developer) to retrieve the current version:
-
-    ```
-    SandboxKeys.imageVersion in Global := "YOUR_CONDUCTR_SANDBOX_VERSION"
-    ```
-3. Reload the sbt session:
-
-    ```scala
-    reload
-    ```    
-
-The plugin is then enabled automatically for your entire project. Additionally it includes `sbt-conductr` and `sbt-bundle` so these plugins doesn't need to be added separately. The `conduct` commands such as `conduct info` will automatically communicate with the Docker cluster managed by the sandbox. There is no need to set ConductR's ip address with `controlServer` manually.
-
-## Using sbt-conductr-sandbox
-
-### Starting ConductR
-
-Start the sandbox inside the sbt session with:
+Afterwards, start the sandbox inside the sbt session with:
 
 ```scala
-[my-app] sandbox run
+[my-app] sandbox run <CONDUCTR_VERSION>
 [info] Running ConductR...
 [info] Running container cond-0 exposing 192.168.59.103:9000...
 ```
 
-> Note that the ConductR sandbox will take a few seconds to become available and so any initial command that you send to it may not work immediately.
+> The ConductR sandbox will take a few seconds to become available and so any initial command that you send to it may not work immediately.
 
 Given the above you will then have a ConductR process running in the background (there will be an initial download cost for Docker to download the conductr/conductr-dev image from the public Docker registry).
 
-#### ConductR features
+### ConductR features
 
-> In order to use the following features then you should ensure that the machine that runs Docker has enough memory, typically at least 2GB. VM configurations such as those provided via `boot2docker` and Oracle's VirtualBox can be configured like so:
->
->     boot2docker down
->     VBoxManage modifyvm boot2docker-vm --memory 2048
->     boot2docker up
-
-ConductR gets shipped with features which can be optionally enabled during startup by specifying the `--withFeatures` option, e.g.:
+The sandbox contains handy features which can be optionally enabled during startup by specifying the `--feature` option, e.g.:
     
 ```scala
-[my-app] sandbox run --withFeatures visualization logging
+[my-app] sandbox run --feature visualization
 [info] Running ConductR...
 [info] Running container cond-0 exposing 192.168.59.103:9000 192.168.59.103:9909...
 ```
@@ -75,64 +34,7 @@ The `visualization` feature provides a web interface to visualize the ConductR c
 
 [[images/visualizer_simple.png]]
 
-The `logging` feature consolidates the logging output of ConductR itself and the bundles that it executes. To view the consolidated log messsages run:
-
-```scala
-conduct logs conductr-elasticsearch
-```
-
-For more information refer to the [[Logging|Logging]] section.
-
-### Debugging ConductR
-
-It is possible to debug your application inside of the ConductR sandbox:
-
-1. Start ConductR sandbox in debug mode:
-
-    ```scala
-    sandbox debug
-    ```
-2. This exposes a debug port to docker and the ConductR container. By default the debug port is set to `5005` which is the default port for remote debugging in IDEs such as IntelliJ. If you are happy with the default setting skip this step. Otherwise specify another port in the `build.sbt`:
-
-    ```scala
-    SandboxKeys.debugPort := 5432
-    ```    
-3. Create the application bundle. The JVM argument `-jvm-debug $debugPort` is automatically added to the bundle configuration when using:
-
-    ```scala
-    bundle:dist
-    ```
-4. Load and run your bundle to the sandbox, e.g. by using [sbt-conductr](https://github.com/sbt/sbt-conductr):
-
-    ```scala
-    conduct load <HIT THE TAB KEY AND THEN RETURN>
-    conduct run my-app
-    ```
-
-You should be now able to remotely debug the bundle inside the ConductRs sandbox with your favorite IDE.
-
-**IntelliJ**
-
-1. In IntelliJ navigate to `Run` -> `Edit Configurations`
-2. Create a new `Remote` configuration with these options:
-    - Transport: Socket
-    - Debugger mode: Attach
-    - Host: Your docker host ip, e.g. 192.168.59.103
-    - Port: `debugPort` of your application, e.g. 5005
-
-    [[images/conductr_sandbox_debugging_intellij.png]]
-3. Save this configuration and start remote debugging with `Run` -> `Debug` and then select your configuration.
-
-**Eclipse**
-
-1. In Eclipse navigate to `Run` -> `Debug Configurations..`
-2. Create a new `Remote Java Application` with these options:
-    - Connection Type: Standard (Socket Attach)
-    - Host: Your docker host ip, e.g. 192.168.59.103
-    - Port: `debugPort` of your application, e.g. 5005
-
-    [[images/conductr_sandbox_debugging_eclipse.png]]
-3. Select `Debug` to start the remote debug session.
+To check out all available features head over to the [features](https://github.com/typesafehub/sbt-conductr#features) section of sbt-conductr.
 
 ### Stop ConductR
 
@@ -141,3 +43,5 @@ To stop the ConductR sandbox use:
 ```scala
 sandbox stop
 ```
+
+For more information about managing a ConductR cluster with sbt-conductr checkout its [documentation](https://github.com/typesafehub/sbt-conductr).

--- a/src/main/play-doc/developer/CreatingBundles.md
+++ b/src/main/play-doc/developer/CreatingBundles.md
@@ -5,29 +5,36 @@ Once the application is ready for deployment, developers can view ConductR bundl
 1. Using an [sbt](http://www.scala-sbt.org/) plugin with your build
 2. Using `shazar` (we invented that name!)
 
-If you can make changes to the application or service that you bundle then `sbt-bundle` is what you will typically use. In fact you can even use sbt-bundle to produce bundles for other applications or services. However you may find yourself crafting a bundle from scratch and for the latter scenario. See the "legacy & third party bundles" section of the [bundles](BundleConfiguration#Legacy-&-third-party-bundles) document for more information on that, and for a deep dive on bundles in general. For now, let's look at bundling a project that you have control of.
+If you can make changes to the application or service then `sbt-conductr` is what you will typically use to produce a bundle. In fact you can even use sbt-conductr to produce bundles for other applications or services. However you may find yourself crafting a bundle from scratch and for the latter scenario. See the "legacy & third party bundles" section of the [bundles](BundleConfiguration#Legacy-&-third-party-bundles) document for more information on that, and for a deep dive on bundles in general. For now, let's look at bundling a project that you have control of.
 
-## sbt-bundle
+## Producing a bundle
 
-The [sbt-native-packager](https://github.com/sbt/sbt-native-packager#sbt-native-packager) has been extended with a plugin named [sbt-bundle](https://github.com/sbt/sbt-bundle#typesafe-conductr-bundle-plugin). Just as developers might use `sbt dist` or `sbt debian:packageBin` to produce production binaries of an application, the sbt `bundle:dist` task from [sbt-bundle](https://github.com/sbt/sbt-bundle#typesafe-conductr-bundle-plugin) is used to produce ConductR application bundles.
+With [sbt-conductr](https://github.com/typesafehub/sbt-conductr) you can produce a ConductR bundle for your application. sbt-conductr extends the [sbt-native-packager](https://github.com/sbt/sbt-native-packager#sbt-native-packager). Just as developers might use `sbt dist` or `sbt debian:packageBin` to produce production binaries of an application, the sbt `bundle:dist` task from sbt-conductr is used to produce ConductR application bundles.
 
-Note that the description here is just to provide a feel of how `sbt-bundle` is used. Please refer to [its documentation](https://github.com/sbt/sbt-bundle#typesafe-conductr-bundle-plugin) as there are some small considerations when dealing with the pre 1.0 `sbt-native-packager` e.g. the one used with Play 2.3.
+Note that the description here is just to provide a feel of how `sbt-conductr` is used. Please refer to [its documentation](https://github.com/typesafehub/sbt-conductr#sbt-conductr) as there are some small considerations when dealing with the pre 1.0 `sbt-native-packager` e.g. the one used with Play 2.3.
 
-Firstly add the sbt plugin, typically to your project's `project/plugins.sbt` file (check [here](https://github.com/sbt/sbt-bundle#usage) for the latest release of sbt-bundle):
-
-```scala
-addSbtPlugin("com.typesafe.sbt" % "sbt-bundle" % "1.2.1")
-```
-
-> If you already added `sbt-conductr-sandbox` then you do not need to have an explicit declaration for `sbt-bundle`. `sbt-bundle` will be automatically added as a dependency of `sbt-conductr-sandbox`.
-
-The plugin will then requiring enabling for your project (note that the plugin is automatically enabled for Play and Lagom projects):
+`sbt-conductr` is triggered for each project that enables a native packager plugin in the `build.sbt`, e.g.:
 
 ```scala
-lazy val root = project.in(file(".")).enablePlugins(JavaAppPackaging)
+lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
 ```
 
-You will then need to declare what are known as "scheduling parameters" for ConductR. These parameters effectively describe what resources are used by your application or service and are used to determine which machine they will run on. Here's a minimum set of parameter specifying that 1 cpu, 64MiB memory and 5MB of disk space is required when your application or service runs:
+Note that Lagom or Play user can enable one of the following plugins instead:
+
+| Project            | Description                                                                         |
+|--------------------|-------------------------------------------------------------------------------------|
+| Lagom Java         | `lazy val myService = (project in file(".")).enablePlugins(LagomJava)`              |
+| Play Java in Lagom | `lazy val myService = (project in file(".")).enablePlugins(LagomPlay)`              |
+| Play Scala 2.4+    | `lazy val root = (project in file(".")).enablePlugins(PlayScala)`                   |
+| Play Scala 2.3     | `lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging, PlayScala)` |
+| Play Java 2.4+     | `lazy val root = (project in file(".")).enablePlugins(PlayJava)`                    |
+| Play Java 2.3      | `lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging, PlayJava)`  |
+
+You will then need to declare what are known as "scheduling parameters" for ConductR. These parameters effectively describe what resources are used by your application or service and are used to determine which machine they will run on. 
+
+The Play and Lagom bundle plugins are providing [default scheduling parameters](https://github.com/typesafehub/sbt-conductr/blob/master/README.md#scheduling-parameters), i.e. it is not mandatory to declare scheduling paramters for these kind of applications. However, we recommend to define custom settings for each of your application.  
+
+In the following example we specify that 1 CPU, 64 MB memory and 5 MB of disk space is required when your application or service runs:
 
 ```scala
 import ByteConversions._
@@ -35,16 +42,14 @@ import ByteConversions._
 BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 5.MB
-```
+``` 
 
-You'll note that the international standards for supporting [binary prefixes](http://en.wikipedia.org/wiki/Binary_prefix), as in `MiB`, is supported. If not specified, the bundle's role defaults to `web`.
-
-Also note that while `BundleKeys.memory` is honored, the other two are ignored by ConductR when running in standalone mode i.e. when not running on a resource provider such as [Mesos](http://mesos.apache.org/). However it is good practice to specify these parameters, and future ConductR releases may indeed honor them.
+You'll note that the international standards for supporting [binary prefixes](http://en.wikipedia.org/wiki/Binary_prefix), as in `MiB`, is supported.
 
 Now create a bundle:
 
 ```scala
-sbt bundle:dist
+bundle:dist
 ```
 
 Take a look in your `target/bundle` folder - you'll see your new bundle with a hash string, something like this:
@@ -57,21 +62,11 @@ i.e. the name of your project (`visualizer`), its version `1.1` and the hash val
 
 Your bundle is now ready for loading into ConductR. What happened there is a few sensible defaults were chosen for you, a `bundle.conf` was generated, and a zip was built containing the output of a Universal build. The plugin then generated a [secure hash](http://en.wikipedia.org/wiki/Secure_Hash_Algorithm) of the zip contents and encoded it in the filename. The secure hash provides a version of your bundle that ConductR is able to verify and thus assure you of its integrity. You can derive a reasonable level of confidence that version xyz of your application or service is always going to be xyz; something that makes you happy if you ever need to reliably rollback to an older version of your software!
 
-Your application or service must be told what interface and port it should bind to when it runs. *You should not assume these binding details.*
+Your application or service must be told what interface and port it should bind to when it runs. The Lagom and Play bundle plugins do that automatically. 
 
 ConductR provides a specific ip address for the application to bind. Binding the provided private address enables the application to limit its network exposure to only the required interface. Furthermore, the port that ConductR provides for binding to is guaranteed to not clash with other bundle components on the same machine, and so it is important to use.
 
-Here is a Play example of declaring the interface and port to bind to:
-
-```scala
-javaOptions in Bundle ++= Seq("-Dhttp.address=$WEB_BIND_IP", "-Dhttp.port=$WEB_BIND_PORT")
-```
-
-`WEB_BIND_IP` and `WEB_BIND_PORT` are environment variables provided by ConductR. ConductR will generate a few useful environment variables for your bundle component. Check out [sbt-bundle's documentation](https://github.com/sbt/sbt-bundle#typesafe-conductr-bundle-plugin) for a comprehensive statement of its capabilities and settings, particularly around configuring your service's endpoints.
-
-By default, sbt-bundle will assume that you have a Play application and it will expose port 9000.
-
-Here's another example, this time of a non-Play application such as an Akka one where [Typesafe config](https://github.com/typesafehub/config#overview) is used to determine the ip and port that your service requires:
+Here is a Akka example one where [Typesafe config](https://github.com/typesafehub/config#overview) is used to determine the ip and port that your service requires:
 
 ```
 customer-service {
@@ -82,6 +77,8 @@ customer-service {
 }
 
 ```
+
+`CUSTOMER_SERVICE_BIND_IP` and `CUSTOMER_SERVICE_BIND_PORT` are environment variables provided by ConductR. ConductR will generate a few useful environment variables for your bundle component. Check out the [bundle settings](https://github.com/typesafehub/sbt-conductr#bundle-settings) of sbt-conductr for a comprehensive statement of its capabilities and settings, particularly around configuring your service's endpoints.
 
 Typesafe config provides the ability to substitute environment variables if they exist. With the above, an ip of 127.0.0.1 and a port of 9000 will be used if ConductR has not been used to start your application. `CUSTOMER_SERVICE` was declared as the name of the endpoint using sbt configuration e.g.:
 
@@ -98,13 +95,13 @@ With the above Typesafe config you can then access the host and ip to use from w
   Http(system).bind(ip, port) // ... and so forth
 ```
 
-#### Preserving paths at the proxy
+### Preserving paths at the proxy
 
 Given the previous example where the service URI was "http://:5444/customers", ConductR will interpret the first path component (`customers`) as the service name for the purposes of service lookup. By default ConductR will then remove the first path component when rewriting the request. This means that your application or service will receive everything under the root of `/` which is quite handy for many web applications where they do not have a context root defined. Where applications or services expect the context root to be preserved when passing through ConductR's proxy, then the service URI can be instead expressed as "http://:5444/customers?preservePath".
 
 > For ConductR 1.2 onward the service URI convention will be able to be expressed using an alternative Access Control List (ACL) feature. ACLs will separate out the service name for the purposes of service lookup, and how an application or service expresses itself for the purposes of proxying (if at all). Furthermore the ACLs will move away from the service URI declaration of how an application or service is presented at the proxy. Instead, proxying concerns will be dealt entirely within ConductR's proxy and not as part of a developer's bundle, leading to a great deal more convenience and flexibility when configuring a proxy.
 
-### Docker bundles
+## Docker bundles
 
 When wanting to create Docker bundles you leverage the sbt-native-packager's ability to generate a Dockerfile and then let sbt-bundle know about this being the desired target. An example [build.sbt configuration for postgres-bdr](https://github.com/huntc/postgres-bdr/blob/master/build.sbt) is shown below:
 

--- a/src/main/play-doc/developer/DeployingBundles.md
+++ b/src/main/play-doc/developer/DeployingBundles.md
@@ -1,58 +1,26 @@
 # Deploying application bundles
 
-Once you've created a bundle you can deploy it using ConductR's RESTful API, even using [curl](http://curl.haxx.se/) if you want. However we've made it a little easier than that. You can of course use ConductR's CLI as discussed in the _Operator Quickstart_ above. Alternatively given that we've been discussing bundling your application or service mostly from an sbt perspective, you can use another plugin named [`sbt-conductr`](https://github.com/sbt/sbt-conductr#sbt-conductr).
+Once you've created a bundle you can deploy it using ConductR's RESTful API, even using [curl](http://curl.haxx.se/) if you want. However we've made it a little easier than that. You can of course use ConductR's CLI as discussed in the [[Operations guide|CLI]]. Alternatively, given that we've been discussing bundling your application or service mostly from an sbt perspective, you can use [sbt-conductr](https://github.com/sbt/sbt-conductr#sbt-conductr). The sbt plugin makes the same commands available within the sbt session as the `conductr-cli` on the terminal.
 
-The following description is intended to provide a taste of what `sbt-conductr` can do for you. Please refer to [its documentation](https://github.com/sbt/sbt-conductr/blob/master/README.md) as there are some small considerations when dealing with the pre 1.0 `sbt-native-packager` e.g. the one used with Play 2.3.
-
-To use `sbt-conductr` first add the plugin your build (typically your `project/plugins.sbt` file); be sure to check at [the plugin's website](https://github.com/sbt/sbt-conductr#sbt-conductr) for the latest version to use:
-
-```scala
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.5.1")
-```
-
-> If you add this plugin as above, you do not need to have an explicit declaration for `sbt-bundle`. `sbt-bundle` will be automatically added as a dependency of `sbt-conductr`. If you have already added `sbt-conductr-sandbox` as an sbt plugin before then `sbt-conductr` doesn't need to be added as well. `sbt-conductr` will be automatically added as a dependency of `sbt-conductr-sandbox`.
-
-The `sbt-bundle` plugin must then be enabled for your project. Supposing that your project has one module that will use the plugin which is the root of the sbt project (the most typical situation for a single `build.sbt`):
-
-```scala
-lazy val root = project
-  .in(file("."))
-  .enablePlugins(JavaAppPackaging, <your other plugins go here>)
-```
-
-> `sbt-bundle` is what is known as an "auto plugin" - it is enabled when certain requirements are met in the build. For example enabling `JavaAppPackaging` triggers the enablement of `sbt-bundle`. For Play based applications, enabling `PlayJava` or `PlayScala` similarly enables sbt-bundle. With Play, both `PlayJava` and `PlayScala` enable `JavaAppPackaging`.
-
-With your declarations out of the way, you can produce a bundle by typing:
-
-```bash
-bundle:dist
-```
-
-A bundle will be produced from the native packager settings of this project. A bundle effectively wraps a native
-packager distribution and includes some component configuration. To load the bundle first declare the location of ConductR (supposing that ConductR is running on `172.14.0.1`:
-
-```bash
-controlServer 172.14.0.1
-```
-
-> When using `sbt-conductr-sandbox` the location of ConductR is automatically set to the docker host ip.
-
-...and then load:
+To deploy a bundle use the `conduct load` command:
 
 ```bash
 conduct load <HIT THE TAB KEY AND THEN RETURN>
 ```
 
 Using the tab completion feature of sbt will produce a URI representing the location of the last distribution
-produced by the native packager.
+produced by the native packager. When using the `sandbox` the location of the ConductR cluster is automatically picked up.
 
-Hitting return will cause the bundle to be uploaded. On successfully uploading the bundle the plugin will report
-the `BundleId` to use for subsequent commands on that bundle.
+To load a bundle to a remote ConductR cluster, use the `--ip` option:
+
+```bash
+conduct load --ip 172.14.0.1 <HIT THE TAB KEY AND THEN RETURN>
+```
+
+On successfully uploading the bundle the plugin will report the `BundleId` to use for subsequent commands on that bundle.
 
 You can also run, stop and unload bundles by using this plugin. This may be useful to support your development lifecycle without having to jump into the operator's CLI.
 
 > The host running sbt in this example must have access to the ConductR daemon ports. Please see  [[Cluster security considerations|ClusterSetupConsiderations#Cluster-security-considerations]] for further information on controlling cluster access.
 
-That is all that is required in essence, but as stated, you should read the [documentation](https://github.com/sbt/sbt-conductr/blob/master/README.md) of `sbt-conductr` as there are a few additional requirements, particularly if you are managing a Play 2.3 application.
-
-Now go and develop reactive applications or services for ConductR!
+That is all that is required in essence. For more information head out to the [documentation](https://github.com/sbt/sbt-conductr/blob/master/README.md) of `sbt-conductr`.

--- a/src/main/play-doc/developer/DevQuickStart.md
+++ b/src/main/play-doc/developer/DevQuickStart.md
@@ -2,14 +2,14 @@
 
 ConductR simplifies the deployment of applications with resilience and elasticity without disrupting the application development lifecycle. Developers continue to develop and test their applications as they normally would prior to deployment.
 
-This guide describes how to setup and deploy a Play 2.4 Scala application on ConductR. In particular it describes how to:
+This guide describes how to setup and deploy a Play 2.5 Scala application on ConductR. In particular it describes how to:
 
-* Signal that application is started
+* Signal that application has started
 * Create an application bundle
 * Start a ConductR cluster
 * Deploy an application bundle to ConductR
 
-The focus of this section is to get started quickly. The full documentation of these parts are described in these sections:
+This section focuses to get you up and running quickly. The full documentation of these parts are described in the sections:
 
 * [[Signaling application state|SignalingApplicationState]]
 * [[Creating bundles|CreatingBundles]]
@@ -28,77 +28,49 @@ sbt is our interactive build tool. Reading the getting started guide for sbt is 
 
 The conductr-cli is used to communicate with the ConductR cluster.
 
+## Adding sbt-conductr plugin
+
+[sbt-conductr](https://github.com/typesafehub/sbt-conductr) is a sbt plugin that provides commands in sbt to: 
+
+* Produce a ConductR bundle
+* Start and stop a local ConductR cluster
+* Manage a ConductR cluster within a sbt session
+
+To use `sbt-conductr` for your project add the plugin to your `project/plugins.sbt`:
+
+```scala
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.0.1")
+```
+
 ## Signaling application state
 
-First let us setup the Play 2.4 application for ConductR. Your application should tell ConductR when it has completed its initialization and is ready for work. For a Play 2.4 application add these dependency to your `build.sbt`:
-
-```scala
-resolvers += "typesafe-releases" at "http://repo.typesafe.com/typesafe/maven-releases"
-
-libraryDependencies += "com.typesafe.conductr" %% "play24-conductr-bundle-lib" % "1.4.2"
-```
-
-Now you can add a guice module in the `application.conf`. This module tells ConductR when your application has been started and therefore ready to start processing requests:
-
-```scala
-play.application.loader = "com.typesafe.conductr.bundlelib.play.ConductRApplicationLoader"
-```
+Your application should tell ConductR when it has completed its initialization and is ready for work. Fortunately, `sbt-conductr` does this for a Play application automatically.
 
 ## Creating application bundle
 
-[sbt-conductr-sandbox](https://github.com/typesafehub/sbt-conductr-sandbox) is an sbt plugin to easily manage your application inside ConductR. This plugin includes [sbt-bundle](https://github.com/sbt/sbt-bundle#typesafe-conductr-bundle-plugin) and [sbt-conductr](https://github.com/sbt/sbt-conductr).
+To produce a bundle for your application use the `bundle:dist` command:
+ 
+```scala
+bundle:dist
+``` 
 
-1. Add `sbt-conductr-sandbox` to the `project/plugins.sbt`:
+The new bundle should be created in your `target/bundle` directory.
 
-    ```scala
-    addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.4.2")
-    ```
-2. Specify `sbt-bundle` keys in the `build.sbt`:   
-
-    ```scala
-    import ByteConversions._
-    BundleKeys.nrOfCpus := 1.0
-    BundleKeys.memory := 64.MiB
-    BundleKeys.diskSpace := 10.MB
-    ```    
-3. Reload the sbt session:
-
-    ```scala
-    reload
-    ```     
-4. Create the bundle inside you sbt session with:
-
-    ```scala
-    bundle:dist
-    ```
-
-The new bundle should be created in your `target/bundle` directory. The `sbt-bundle` effectively describe what resources are used by your application and are used to determine which machine they will run on in the ConductR cluster. For example, 64 MiB means that your bundle will require a total of 64 megabytes of memory to run on its machine. Knowing this information helps ConductR schedule your bundle's execution where there are resources available. You should always profile your application or service in order to understand what resources it will require.
-
-As you move through our documentation you will  come across references to ConductR's environment variables e.g. `MY_APP_BIND_PORT`. Please refer to [our documentation](BundleEnvironmentVariables) for information on the meaning of these environment variables should you need to.
+As you move through our documentation you will come across references to ConductR's environment variables e.g. `MY_APP_BIND_PORT`. Please refer to [our documentation](BundleEnvironmentVariables) for information on the meaning of these environment variables should you need to.
 
 ## Starting ConductR cluster
 
-Now we can go ahead an start the ConductR cluster locally.
+Now, you can go ahead and start the ConductR cluster locally. For that you should use the ConductR sandbox which is a docker image based on Ubuntu that includes ConductR. With this docker image you can easily spin up multiple ConductR nodes on your local machine. The `sandbox run` command will pick up and run this ConductR docker image. In order to use this command we need to specify the ConductR version. Please visit the [ConductR Developer page](https://www.lightbend.com/product/conductr/developer) to pick up the latest ConductR version from the section **Quick Configuration**.
 
-1. Specify the ConductR Developer Sandbox version in the `build.sbt`. This version is available gratis during development with registration at lightbend.com. Please visit the [ConductR Developer page](http://www.lightbend.com/product/conductr/developer) to retrieve the current version:
+Afterwards, you can start the ConductR cluster by executing:
 
-    ```
-    SandboxKeys.imageVersion in Global := "YOUR_CONDUCTR_SANDBOX_VERSION"
-    ```
-2. Reload the sbt session:
+```scala
+sandbox run --feature visualization
+[info] Running ConductR...
+[info] Running container cond-0 exposing 192.168.59.103:9909...
+```
 
-    ```scala
-    reload
-    ``` 
-        
-3. Start ConductR cluster with visualization feature:
-    
-    ```scala
-    [my-app] sandbox run --withFeatures visualization
-    [info] Running ConductR...
-    [info] Running container cond-0 exposing 192.168.59.103:9909...
-    ```
-4. Access ConductR visualizer at `http://{docker-host-ip}:9909` where `docker-host-ip` is the host of your docker environment. For convenience, the url of the visualizer app is displayed in the sbt session, e.g. http://192.168.59.103:9909.
+The `visualization` feature is simple Play application that visualizes the ConductR cluster state. Access the ConductR visualizer at `http://{docker-host-ip}:9909` where `docker-host-ip` is the host of your docker environment. For convenience, the url of the visualizer app is displayed in the sbt session, e.g. http://192.168.59.103:9909.
 
 [[images/visualizer_simple.png]]
 

--- a/src/main/play-doc/developer/SetupSbtConductr.md
+++ b/src/main/play-doc/developer/SetupSbtConductr.md
@@ -1,0 +1,26 @@
+# Setup sbt-conductr
+
+[sbt-conductr](https://github.com/typesafehub/sbt-conductr) is a sbt plugin that provides commands in sbt to:
+
+* Produce a ConductR bundle and bundle configuration
+* Start and stop a local ConductR cluster
+* Manage a ConductR cluster within a sbt session
+
+## Prerequisites
+
+* [Docker](https://www.docker.com/)
+* [conductr-cli](CLI#New-CLI-installation)
+
+Docker is required so that you can run the ConductR cluster as if it were running on a number of machines in your network. You won't need to understand much about Docker for ConductR other than installing it as described in its "Get Started" section. If you are on Windows or Mac then you will become familiar with `docker-machine` which is a utility that controls a virtual machine for the purposes of running Docker.
+
+The conductr-cli is used to communicate with the ConductR cluster.
+
+## Setup
+
+Add sbt-conductr to your `project/plugins.sbt`:
+
+```scala
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.0.1")
+```
+
+This makes several commands available within sbt. We'll use these commands on the next pages.

--- a/src/main/play-doc/developer/SignalingApplicationState.md
+++ b/src/main/play-doc/developer/SignalingApplicationState.md
@@ -1,5 +1,7 @@
 # Signaling application state
 
+> For Play and Lagom applications, `sbt-conductr` automatically signals that the application has been started or exited. For these kind of application the following instructions can be skipped.
+
 Your application or service should tell ConductR when it has completed its initialization and is ready for work. We have a fall-back strategy for where this is not possible or practical (more on that later), but for now, let's assume that you can modify your source code.
 
 For a [Play](https://www.playframework.com/) application or service, signalling successful startup may be when its http endpoint is online having declared a connection to a database. For an [Akka](http://akka.io/) based application then it may be when your actor system has been initialized and you have connected to some other service.
@@ -18,8 +20,8 @@ To use it add one of the libraries as a dependency to your `build.sbt`:
 ```scala
 resolvers += "typesafe-releases" at "http://repo.lightbend.com/typesafe/maven-releases"
 
-libraryDependencies += "com.typesafe.conductr" %% "scala-conductr-bundle-lib" % "1.4.2"
-```
+libraryDependencies += "com.typesafe.conductr" %% "scala-conductr-bundle-lib" % "1.4.3"
+``` 
 
 The Java and Scala / JDK library have no dependencies other than the JDK and as such, a blocking implementation is used for its HTTP calls (the JDK offers no non-blocking APIs for this). Using the Akka or Play library will ensure that the library is consistent with the respective Akka or Play application and that non-blocking implementations are used:
 - Akka: akka-http

--- a/src/main/play-doc/developer/index.toc
+++ b/src/main/play-doc/developer/index.toc
@@ -1,11 +1,12 @@
 DevQuickStart: Quick start
+SetupSbtConductr: Setup sbt-conductr
 SignalingApplicationState:Signaling application state
-ResolvingServices:Resolving other services
-AkkaAndPlay:Akka and Play specifics
+ConductrSandbox:Managing ConductR sandbox
 CreatingBundles: Creating bundles
 DeployingBundles:Deploying bundles
 BundleConfiguration:Bundle configuration
+ResolvingServices:Resolving other services
+AkkaAndPlay:Bundle library flavors
 BundleEnvironmentVariables:Environment variables
-ConductrSandbox:Advanced sandbox
 TCPLookups:TCP & UDP service lookups
 Filesystems:Filesystems

--- a/src/main/play-doc/operation/DeployingBundlesOps.md
+++ b/src/main/play-doc/operation/DeployingBundlesOps.md
@@ -86,7 +86,7 @@ conduct load /tmp/downloads/reactive-maps-frontend-v1-023f9da2243a0751c2e231b452
 conduct load http://192.168.0.1/files/reactive-maps-frontend-v1-023f9da2243a0751c2e231b452aa3ed32fbc35351c543fbd536eea7ec457cfe2.zip
 ```
 
-The Bintray resolver accepts a [bundle shorthand expression](#Bundle-shorthand-expression) which is translated to a Bintray download URL. Bundles can be published to Bintray using [sbt-bundle](https://github.com/sbt/sbt-bintray-bundle) plugin.
+The Bintray resolver accepts a [bundle shorthand expression](#Bundle-shorthand-expression) which is translated to a Bintray download URL. Bundles can be published to Bintray using [sbt-bintray-bundle](https://github.com/sbt/sbt-bintray-bundle) plugin.
 
 
 ## Bundle shorthand expression


### PR DESCRIPTION
sbt-conductr 2.0.0 harmonized all sbt plugins into one. Due to this fact also the dev guide has been changed dramatically. In particular:
- A new `Setup sbt-conductr` section has been added. Reason is that this action is necessary for all other documentation pages. Therefore I found it necessary to create a separate page for that. The installation instructions of sbt plugins inside the other pages have been removed and instead they mention sbt-conductr.
- The order of the pages has changed to optimize the reading flow:
  - Quick start
  - Setup sbt-conductr
  - Signaling application state
  - Managing ConductR sandbox
  - Creating bundles
  - Deploying bundles
  - ...
- The sbt-conductr dev guide pages have been updated
