### PR TITLE
 Latest conductr-lib and sbt-conductr plugin

### DIFF
--- a/src/main/play-doc/developer/ConductrSandbox.md
+++ b/src/main/play-doc/developer/ConductrSandbox.md
@@ -25,7 +25,7 @@ Given the above you will then have a ConductR process running in the background 
 The sandbox contains handy features which can be optionally enabled during startup by specifying the `--feature` option, e.g.:
     
 ```scala
-[my-app] sandbox run --feature visualization
+[my-app] sandbox run <CONDUCTR_VERSION> --feature visualization
 [info] Running ConductR...
 [info] Running container cond-0 exposing 192.168.59.103:9000 192.168.59.103:9909...
 ```

--- a/src/main/play-doc/developer/DeployingBundles.md
+++ b/src/main/play-doc/developer/DeployingBundles.md
@@ -2,7 +2,9 @@
 
 Once you've created a bundle you can deploy it using ConductR's RESTful API, even using [curl](http://curl.haxx.se/) if you want. However we've made it a little easier than that. You can of course use ConductR's CLI as discussed in the [[Operations guide|CLI]]. Alternatively, given that we've been discussing bundling your application or service mostly from an sbt perspective, you can use [sbt-conductr](https://github.com/sbt/sbt-conductr#sbt-conductr). The sbt plugin makes the same commands available within the sbt session as the `conductr-cli` on the terminal.
 
-To deploy a bundle use the `conduct load` command:
+The quickstart section introduced the `install` command so that you can conveniently load and run your entire project in ConductR. You can also control the loading and running of a bundle with `conduct` sub commands.
+
+To load a bundle use the `conduct load` command:
 
 ```bash
 conduct load <HIT THE TAB KEY AND THEN RETURN>
@@ -24,3 +26,7 @@ You can also run, stop and unload bundles by using this plugin. This may be usef
 > The host running sbt in this example must have access to the ConductR daemon ports. Please see  [[Cluster security considerations|ClusterSetupConsiderations#Cluster-security-considerations]] for further information on controlling cluster access.
 
 That is all that is required in essence. For more information head out to the [documentation](https://github.com/sbt/sbt-conductr/blob/master/README.md) of `sbt-conductr`.
+
+## Generating an installation script
+
+An installation script can be conveniently generated for your project. Just like the `install` command, a `generateInstallationScript` command will introspect your project for bundles and associated configurations and then generate a bash based script. You are encouraged to copy this script and tailor it so that you can conveniently deploy your project's bundles to production and other environments.

--- a/src/main/play-doc/developer/DevQuickStart.md
+++ b/src/main/play-doc/developer/DevQuickStart.md
@@ -39,7 +39,7 @@ The conductr-cli is used to communicate with the ConductR cluster.
 To use `sbt-conductr` for your project add the plugin to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.0.1")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.0")
 ```
 
 ## Signaling application state
@@ -48,7 +48,7 @@ Your application should tell ConductR when it has completed its initialization a
 
 ## Creating application bundle
 
-To produce a bundle for your application use the `bundle:dist` command:
+To produce a bundle for your application use the `bundle:dist` command from within sbt:
  
 ```scala
 bundle:dist
@@ -62,10 +62,10 @@ As you move through our documentation you will come across references to Conduct
 
 Now, you can go ahead and start the ConductR cluster locally. For that you should use the ConductR sandbox which is a docker image based on Ubuntu that includes ConductR. With this docker image you can easily spin up multiple ConductR nodes on your local machine. The `sandbox run` command will pick up and run this ConductR docker image. In order to use this command we need to specify the ConductR version. Please visit the [ConductR Developer page](https://www.lightbend.com/product/conductr/developer) to pick up the latest ConductR version from the section **Quick Configuration**.
 
-Afterwards, you can start the ConductR cluster by executing:
+Afterwards, you can start the ConductR cluster by executing the following from within sbt:
 
 ```scala
-sandbox run --feature visualization
+sandbox run <CONDUCTR_VERSION> --feature visualization
 [info] Running ConductR...
 [info] Running container cond-0 exposing 192.168.59.103:9909...
 ```
@@ -76,21 +76,18 @@ The `visualization` feature is simple Play application that visualizes the Condu
 
 ## Deploying application bundle to ConductR
 
-1. Load your application bundle to ConductR:
-    
-    ```scala
-    conduct load <HIT THE TAB KEY AND THEN RETURN>
-    ```
-2. Run bundle on one node:
-    
-    ```scala
-    conduct run my-app
-    ```
+From within sbt:
 
-3. Access your application at http://docker-host-ip:9000.
+```scala
+install
+```
+
+The above will introspect your project and any sub projects for bundles and their configuration, restart the sandbox to ensure a clean state and then load and run your bundles. You can then access your application at http://docker-host-ip:9000.
 
 In the visualizer web interface you should see now two bundles running, the visualizer bundle itself and your application bundle.
 
 [[images/visualizer_with_app.png]]
 
 That's it! You now have ConductR running with the visualizer and your own application. Head over to the next chapters to learn in greater detail how to setup, configure and run your applications on ConductR.
+
+> Note that the `conduct` and `sandbox` commands are also available from the command line for usage outside of sbt.

--- a/src/main/play-doc/developer/SetupSbtConductr.md
+++ b/src/main/play-doc/developer/SetupSbtConductr.md
@@ -20,7 +20,7 @@ The conductr-cli is used to communicate with the ConductR cluster.
 Add sbt-conductr to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.0.1")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.0")
 ```
 
 This makes several commands available within sbt. We'll use these commands on the next pages.

--- a/src/main/play-doc/developer/SignalingApplicationState.md
+++ b/src/main/play-doc/developer/SignalingApplicationState.md
@@ -18,9 +18,7 @@ The library comes in multiple flavours:
 To use it add one of the libraries as a dependency to your `build.sbt`:
 
 ```scala
-resolvers += "typesafe-releases" at "http://repo.lightbend.com/typesafe/maven-releases"
-
-libraryDependencies += "com.typesafe.conductr" %% "scala-conductr-bundle-lib" % "1.4.3"
+libraryDependencies += "com.typesafe.conductr" %% "scala-conductr-bundle-lib" % "1.4.4"
 ``` 
 
 The Java and Scala / JDK library have no dependencies other than the JDK and as such, a blocking implementation is used for its HTTP calls (the JDK offers no non-blocking APIs for this). Using the Akka or Play library will ensure that the library is consistent with the respective Akka or Play application and that non-blocking implementations are used:

--- a/src/main/play-doc/general/ReleaseNotes.md
+++ b/src/main/play-doc/general/ReleaseNotes.md
@@ -15,11 +15,9 @@
 
 4. Ensure that bundles are always written to a single volume of a node. This ensures the ability to atomically move a bundle when using an operator specified bundle location.
 
-5. Utilize sbt-conductr 2.0.1, providing a consistent developer sandbox experience from both sbt and the command line.
+5. Adds bundle id and configuration id to ESlite service. Improves ESlite tests.
 
-6. Adds bundle id and configuration id to ESlite service. Improves ESlite tests.
-
-7. Improvements to ConductR tests including upgrading Scala test versions, using Trireme for sbt-mocha and concurrency restrictions to address inconsistent test issues.
+6. Improvements to ConductR tests including upgrading Scala test versions, using Trireme for sbt-mocha and concurrency restrictions to address inconsistent test issues.
 
 ### 1.1.3 - Apr 15, 2016
 


### PR DESCRIPTION
Changes to reflect the latest conductr-lib version, and also the introduction of the new sbt-conductr `install` command.
