### PR TITLE
Memory explanation

### DIFF
--- a/src/main/play-doc/developer/BundleConfiguration.md
+++ b/src/main/play-doc/developer/BundleConfiguration.md
@@ -12,7 +12,7 @@ compatibilityVersion  = "1"
 system                = "simple-test"
 systemVersion         = "1"
 nrOfCpus              = 1.0
-memory                = 67108864
+memory                = 134217728
 diskSpace             = 10485760
 roles                 = ["web"]
 components = {
@@ -42,7 +42,7 @@ description			 | A human readable description of the bundle component.
 diskSpace            | The amount of disk space required to host an expanded bundle and configuration.
 endpoints            | Discussed [below](#Endpoints).
 file-system-type	 | Describes the type of the bundle and can be either "universal" or "docker". A universal type means that this bundle copmonent will be run outside of a container. The Host environment will therefore be available, including a Java runtime. Docker types expect a Dockerfile to reside within a component. The Docker component will be built and run at the time of the bundle being run.
-memory               | The total amount of system memory required to run the bundle.
+memory               | The amount of resident memory required to run the bundle. Use the Unix top command to determine this value by observing the RES and rounding up to the nearest 10MiB.
 name				 | The human readable name of the bundle. This name appears often in operational output such as the CLI.
 nrOfCpus             | The number of cpus required to run the bundle (can be fractions thereby expressing a portion of CPU). Required.
 protocol			 | Discussed [below](#Endpoints).

--- a/src/main/play-doc/developer/CreatingBundles.md
+++ b/src/main/play-doc/developer/CreatingBundles.md
@@ -32,15 +32,20 @@ Note that Lagom or Play user can enable one of the following plugins instead:
 
 You will then need to declare what are known as "scheduling parameters" for ConductR. These parameters effectively describe what resources are used by your application or service and are used to determine which machine they will run on. 
 
-The Play and Lagom bundle plugins are providing [default scheduling parameters](https://github.com/typesafehub/sbt-conductr/blob/master/README.md#scheduling-parameters), i.e. it is not mandatory to declare scheduling paramters for these kind of applications. However, we recommend to define custom settings for each of your application.  
+The Play and Lagom bundle plugins provide [default scheduling parameters](https://github.com/typesafehub/sbt-conductr/blob/master/README.md#scheduling-parameters), i.e. it is not mandatory to declare scheduling parameters for these kind of applications. However, we recommend to define custom settings for each of your application.  
 
-In the following example we specify that 1 CPU, 64 MB memory and 5 MB of disk space is required when your application or service runs:
+In the following example we specify that 1 CPU, 64 MiB JVM heap memory, 128 MiB resident memory and 5 MB of disk space is required when your application or service runs:
 
 ```scala
 import ByteConversions._
 
+javaOptions in Universal := Seq(
+  "-J-Xmx64m",
+  "-J-Xms64m"
+)
+
 BundleKeys.nrOfCpus := 1.0
-BundleKeys.memory := 64.MiB
+BundleKeys.memory := 128.MiB
 BundleKeys.diskSpace := 5.MB
 ``` 
 
@@ -94,6 +99,12 @@ With the above Typesafe config you can then access the host and ip to use from w
   val port = config.getInt("customer-service.port")
   Http(system).bind(ip, port) // ... and so forth
 ```
+
+### More on memory
+
+The javaOptions values declare the maximum and minimum heap size for your application respectively. Profiling your application under load will help you determine an optimal heap size. We recommend declaring the BundleKeys.memory value to be approximately twice that of the heap size. BundleKeys.memory represents the resident memory size of your application, which includes the heap, thread stacks, code caches, the code itself and so forth. On Unix, use the top command and observe the resident memory column (RES) with your application under load.
+
+BundleKeys.memory is used for locating machines with enough resources to run your application, and so it is particularly important to size it before you go to production.
 
 ### Preserving paths at the proxy
 

--- a/src/main/play-doc/developer/DevQuickStart.md
+++ b/src/main/play-doc/developer/DevQuickStart.md
@@ -39,7 +39,7 @@ The conductr-cli is used to communicate with the ConductR cluster.
 To use `sbt-conductr` for your project add the plugin to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.4")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.5")
 ```
 
 ## Signaling application state

--- a/src/main/play-doc/developer/SetupSbtConductr.md
+++ b/src/main/play-doc/developer/SetupSbtConductr.md
@@ -20,7 +20,7 @@ The conductr-cli is used to communicate with the ConductR cluster.
 Add sbt-conductr to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.4")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.5")
 ```
 
 This makes several commands available within sbt. We'll use these commands on the next pages.


### PR DESCRIPTION
Now discusses the distinction between heap and resident memory.

Also version bumps the sbt-conductr plugin in order to incorporate the same distinction that it makes.
