### PR TITLE
Update monitoring documentation

### DIFF
--- a/src/main/play-doc/operation/ConfigurationRef.md
+++ b/src/main/play-doc/operation/ConfigurationRef.md
@@ -535,7 +535,7 @@ cinnamon {
 
   instrumentation = off
 
-  takipi.actors {
+  akka.actors {
     "/user/*" {
       report-by = class
     }

--- a/src/main/play-doc/operation/Monitoring.md
+++ b/src/main/play-doc/operation/Monitoring.md
@@ -1,12 +1,12 @@
-# Typesafe Monitoring
+# Lightbend Monitoring
 
-[Typesafe Monitoring](http://www.lightbend.com/products/typesafe-monitoring) is a suite of insight tools for monitoring Typesafe Reactive Platform (RP) applications. These tools gain visibility into ConductR and its bundles — to respond early to changes that could indicate problems, to tune a system, or to track down the cause of unexpected behavior.
+[Lightbend Monitoring](http://www.lightbend.com/products/monitoring) is a suite of insight tools for monitoring Lightbend Platform applications. These tools gain visibility into ConductR and its bundles — to respond early to changes that could indicate problems, to tune a system, or to track down the cause of unexpected behavior.
 
-This guide discusses ConductR specifics regarding Lightbend Monitoring. For a comprehensive description please visit [Lightbend Monitoring's documentation](http://resources.typesafe.com/monitoring/docs/home.html).
+This guide discusses ConductR specifics regarding Lightbend Monitoring. For a comprehensive description please visit [Lightbend Monitoring's documentation](http://monitoring.lightbend.com/docs/latest/home.html).
 
 ## Monitoring ConductR
 
-ConductR is a Lightbend RP based application and has been configured to support Typesafe Monitoring by enabling some settings within its `conf/application.ini`.
+ConductR is a Lightbend Platform based application and has been configured to support Lightbend Monitoring by enabling some settings within its `conf/application.ini`.
 
 ### Enabling ConductR Monitoring for Takipi
 
@@ -42,4 +42,4 @@ javaOptions in Bundle ++= Seq(
   )
 ```
 
-Be sure to have your bundle developers become familiar with ["Cinnamon"](http://resources.typesafe.com/monitoring/docs/install/cinnamon.html) - Typesafe Monitoring's API.
+Be sure to have your bundle developers become familiar with ["Cinnamon"](http://monitoring.lightbend.com/docs/latest/home.html) - Lightbend Monitoring's API.

--- a/src/main/play-doc/operation/index.toc
+++ b/src/main/play-doc/operation/index.toc
@@ -2,7 +2,7 @@ Install:Installation
 CLI:CLI
 DeployingBundlesOps:Deploying bundles
 Logging:Logging
-Monitoring:Typesafe Monitoring
+Monitoring:Lightbend Monitoring
 ManageServices:Managing ConductR services
 ClusterSetupConsiderations:Cluster setup considerations
 ClusterTroubleshooting:Cluster troubleshooting


### PR DESCRIPTION
- rename from Typesafe Monitoring to Lightbend Monitoring
- update monitoring documentation links
- update monitoring configuration reference

This is pointing at the `latest` documentation link for monitoring. We haven't yet switched this over to the 2.0 version, as that's waiting on the full RPv2 release.
