### PR TITLE
Change default nrOfCpus to 0.1

### DIFF
--- a/src/main/play-doc/api/ControlAPI.md
+++ b/src/main/play-doc/api/ControlAPI.md
@@ -278,8 +278,8 @@ hasError            | `true` if some event in ConductR has raised an error, `fal
 host                | The ip address of the machine hosting the bundle's components.
 hostPort            | The port of the machine hosting the bundle component that will be mapped to the `bindPort`. `hostPort` is distinct across all services running on a host.
 isStarted           | `true` if the bundle has signalled that it has started successfully, `false` if it is in the process of starting up.
-memory              | The amount of memory required when a bundle is running. Values are expressed in bytes.
-nrOfCpus            | The number of cpus required when a bundle is running. This value can be expressed as a fraction.
+memory              | The amount of resident memory required to run the bundle. Values are expressed in bytes.
+nrOfCpus            | The minimum number of cpus required to run the bundle (can be fractions thereby expressing a portion of CPU). This value is considered when starting a bundle on a node. If the specified CPUs exceeds the available CPUs on a node, then this node is not considered for scaling the bundle. Once running, the application is not restricted to the given value and tries to use all available CPUs on the node.
 roles               | An array of strings representing the roles that a bundle plays in a ConductR cluster. These roles are matched for eligibility with cluster members when searching for one to load and scale on. Only cluster members with matching roles will be selected.
 scale               | The requested number of instance(s) of the bundle to be started and run.
 services            | An array of string URIs providing the addresses for a given endpoint's proxying.

--- a/src/main/play-doc/developer/BundleConfiguration.md
+++ b/src/main/play-doc/developer/BundleConfiguration.md
@@ -11,7 +11,7 @@ name                  = "simple-test"
 compatibilityVersion  = "1"
 system                = "simple-test"
 systemVersion         = "1"
-nrOfCpus              = 1.0
+nrOfCpus              = 0.1
 memory                = 134217728
 diskSpace             = 10485760
 roles                 = ["web"]
@@ -55,7 +55,7 @@ endpoints            | Discussed [below](#Endpoints).
 file-system-type	 | Describes the type of the bundle and can be either "universal" or "docker". A universal type means that this bundle copmonent will be run outside of a container. The Host environment will therefore be available, including a Java runtime. Docker types expect a Dockerfile to reside within a component. The Docker component will be built and run at the time of the bundle being run.
 memory               | The amount of resident memory required to run the bundle. Use the Unix top command to determine this value by observing the RES and rounding up to the nearest 10MiB.
 name				 | The human readable name of the bundle. This name appears often in operational output such as the CLI.
-nrOfCpus             | The number of cpus required to run the bundle (can be fractions thereby expressing a portion of CPU). Required.
+nrOfCpus             | The minimum number of cpus required to run the bundle (can be fractions thereby expressing a portion of CPU). This value is considered when starting a bundle on a node. If the specified CPUs exceeds the available CPUs on a node, then this node is not considered for scaling the bundle. Once running, the application is not restricted to the given value and tries to use all available CPUs on the node. Required.
 protocol			 | Discussed [below](#Endpoints).
 roles                | The types of node in the cluster that this bundle can be deployed to. Defaults to "web".
 service-name	     | Discussed [below](#Endpoints).
@@ -135,7 +135,7 @@ compatibilityVersion  = "1"
 system         = "jms-docker"
 systemVersion  = "1"
 
-nrOfCpus   = 1.0
+nrOfCpus   = 0.1
 memory     = 67108864
 diskSpace  = 10485760
 roles      = ["jms"]

--- a/src/main/play-doc/developer/CreatingBundles.md
+++ b/src/main/play-doc/developer/CreatingBundles.md
@@ -34,7 +34,7 @@ You will then need to declare what are known as "scheduling parameters" for Cond
 
 The Play and Lagom bundle plugins provide [default scheduling parameters](https://github.com/typesafehub/sbt-conductr/blob/master/README.md#scheduling-parameters), i.e. it is not mandatory to declare scheduling parameters for these kind of applications. However, we recommend to define custom settings for each of your application.  
 
-In the following example we specify that 1 CPU, 64 MiB JVM heap memory, 128 MiB resident memory and 5 MB of disk space is required when your application or service runs:
+In the following example we specify that 0.1 CPU, 64 MiB JVM heap memory, 128 MiB resident memory and 5 MB of disk space is required when your application or service runs:
 
 ```scala
 import ByteConversions._
@@ -44,7 +44,7 @@ javaOptions in Universal := Seq(
   "-J-Xms64m"
 )
 
-BundleKeys.nrOfCpus := 1.0
+BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 128.MiB
 BundleKeys.diskSpace := 5.MB
 ``` 

--- a/src/main/play-doc/developer/DevQuickStart.md
+++ b/src/main/play-doc/developer/DevQuickStart.md
@@ -39,7 +39,7 @@ The conductr-cli is used to communicate with the ConductR cluster.
 To use `sbt-conductr` for your project add the plugin to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.6")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.7")
 ```
 
 ## Signaling application state

--- a/src/main/play-doc/developer/SetupSbtConductr.md
+++ b/src/main/play-doc/developer/SetupSbtConductr.md
@@ -20,7 +20,7 @@ The conductr-cli is used to communicate with the ConductR cluster.
 Add sbt-conductr to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.6")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.7")
 ```
 
 This makes several commands available within sbt. We'll use these commands on the next pages.


### PR DESCRIPTION
- Bump sbt-conductr version to 2.1.7
- Changes the default value of nrOfCpus from `1.0` to `0.1`.

This PR updates the `master` branch.
