### PR TITLE
Further v2 updates

### DIFF
--- a/src/main/play-doc/operation/ConfigurationRef.md
+++ b/src/main/play-doc/operation/ConfigurationRef.md
@@ -158,12 +158,7 @@ conductr {
   mode = "standalone"
 
   # The directory where bundles and their configuration are written to.
-  storage-dir = ${java.io.tmpdir}/bundles
-
-  # The directory where bundles record their pids for the purposes of being reaped if they're still
-  # hanging around when ConductR restarts (perhaps due to ConductR having been rudely killed via
-  # SIGKILL).
-  bundle-pidfile-dir = ${java.io.tmpdir}/bundles/pids
+  storage-dir = ${java.io.tmpdir}/conductr/bundles
 
   # The amount of time Typesafe ConductR expects to wait on achieving a read quorum. 10 seconds should
   # cover large clusters, but you may need to increase this if read timeouts appear
@@ -764,12 +759,12 @@ conductr.agent {
   mode = "standalone"
 
   # The directory where bundles and their configuration are written to.
-  storage-dir = ${java.io.tmpdir}/bundles
+  storage-dir = ${java.io.tmpdir}/conductr-agent/bundles
 
   # The directory where bundles record their pids for the purposes of being reaped if they're still
   # hanging around when ConductR restarts (perhaps due to ConductR having been rudely killed via
   # SIGKILL).
-  bundle-pidfile-dir = ${java.io.tmpdir}/bundles/pids
+  bundle-pidfile-dir = ${java.io.tmpdir}/conductr-agent/bundles/pids
 
   # The address and port of the ConductR Core's `remote.netty.tcp.hostname` and `remote.netty.tcp.port` respectively.
   # This is used by the ConductR agent's Akka cluster client to form the initial contact so connection to

--- a/src/main/play-doc/operation/Install.md
+++ b/src/main/play-doc/operation/Install.md
@@ -131,13 +131,6 @@ ConductR Agent needs to be connected to a ConductR core node in order for Conduc
 [172.17.0.1]$ echo --core-node $(hostname):9004 | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini
 ```
 
-By default ConductR Agent and ConductR Core are using `/tmp` as its working directory. Since both ConductR Agent and ConductR Core are installed in the same machine, move the ConductR Agent working directory as such:
-
-```bash
-[172.17.0.1]$ echo -Dconductr.agent.storage-dir=/tmp/conductr-agent/bundles | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini
-[172.17.0.1]$ echo -Dconductr.agent.bundle-pidfile-dir=/tmp/conductr-agent/bundles/pids | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini
-```
-
 Once configured, restart the ConductR Agent service.
 
 ```bash
@@ -229,8 +222,6 @@ then
 ```bash
 [172.17.0.1]$ echo -Dconductr.agent.ip=$(hostname) | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini
 [172.17.0.1]$ echo --core-node $(hostname):9004 | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini
-[172.17.0.1]$ echo -Dconductr.agent.storage-dir=/tmp/conductr-agent/bundles | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini
-[172.17.0.1]$ echo -Dconductr.agent.bundle-pidfile-dir=/tmp/conductr-agent/bundles/pids | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini
 [172.17.0.1]$ sudo service conductr-agent restart
 ```
 
@@ -270,35 +261,16 @@ First, we have the user `conductr-agent` own the HAProxy config file.
 [172.17.0.1]$ sudo chown conductr-agent:conductr-agent /etc/haproxy/haproxy.cfg
 ```
 
-### Installing HAProxy reload script
+### Preparing HAProxy reload script
 
 After updating the HAProxy configuration file, ConductR-HAProxy will signal HAProxy to reload for the updated configuration.
 
-Create HAProxy reload script in `/usr/bin/reloadHAProxy.sh`.
-
-```bash
-[172.17.0.1]$ sudo touch /usr/bin/reloadHAProxy.sh
-```
-
-Populate the script with the command to reload HAProxy for `systemv` and `upstart`:
-
-```bash
-#!/usr/bin/env bash
-
-/etc/init.d/haproxy reload
-```
-
-For `systemd`:
-
-```bash
-#!/usr/bin/env bash
-
-/bin/systemctl reload haproxy.service
-```
+Prepare the reload script in `/usr/bin/reloadHAProxy.sh`. ConductR-HAProxy to install its reload script in this location upon startup.
 
 We will limit the bundle's sudo privileges to running `/usr/bin/reloadHAProxy.sh`. Grant permissions to the `conductr-agent` user to run the `reloadHAPRoxy.sh` command. An addition to `/etc/sudoers` allows for using `sudo` without password for the `reloadHAProxy.sh` script. If a more specific reload sequence is required, a custom reload script can be specified using the CONDUCTR_RELOADHAPROXY_SCRIPT environment variable in a configuration bundle.
 
 ```bash
+[172.17.0.1]$ sudo touch /usr/bin/reloadHAProxy.sh
 [172.17.0.1]$ sudo chmod 0550 /usr/bin/reloadHAProxy.sh
 [172.17.0.1]$ sudo chown conductr-agent:conductr-agent /usr/bin/reloadHAProxy.sh
 [172.17.0.1]$ echo "conductr-agent ALL=(root) NOPASSWD: /usr/bin/reloadHAProxy.sh" | sudo tee -a /etc/sudoers
@@ -551,35 +523,16 @@ First, we have the user `conductr-agent` own the HAProxy config file.
 [172.17.0.1]$ sudo chown conductr-agent:conductr-agent /etc/haproxy/haproxy.cfg
 ```
 
-#### Installing HAProxy reload script
+#### Preparing HAProxy reload script
 
 After updating the HAProxy configuration file, ConductR-HAProxy will signal HAProxy to reload for the updated configuration.
 
-Create HAProxy reload script in `/usr/bin/reloadHAProxy.sh`.
-
-```bash
-[172.17.0.1]$ sudo touch /usr/bin/reloadHAProxy.sh
-```
-
-Populate the script with the command to reload HAProxy for `systemv` and `upstart`:
-
-```bash
-#!/usr/bin/env bash
-
-/etc/init.d/haproxy reload
-```
-
-For `systemd`:
-
-```bash
-#!/usr/bin/env bash
-
-/bin/systemctl reload haproxy.service
-```
+Prepare the reload script in `/usr/bin/reloadHAProxy.sh`. ConductR-HAProxy to install its reload script in this location upon startup.
 
 We will limit the bundle's sudo privileges to running a single script in `/usr/bin` for that purpose. Grant permissions to the `conductr-agent` user to write and run the `reloadHAPRoxy.sh` command. An addition to `/etc/sudoers` allows for using `sudo` without password for the `reloadHAProxy.sh` script. If a more specific reload sequence is required, a custom reload script can be specified using the CONDUCTR_RELOADHAPROXY_SCRIPT environment variable in a configuration bundle.
 
 ```bash
+[172.17.0.1]$ sudo touch /usr/bin/reloadHAProxy.sh
 [172.17.0.1]$ sudo chmod 0770 /usr/bin/reloadHAProxy.sh
 [172.17.0.1]$ sudo chown conductr-agent:conductr-agent /usr/bin/reloadHAProxy.sh
 [172.17.0.1]$ echo "conductr-agent ALL=(root) NOPASSWD: /usr/bin/reloadHAProxy.sh" | sudo tee -a /etc/sudoers
@@ -681,13 +634,6 @@ ConductR Agent needs to be connected to a ConductR core node in order for Conduc
 ```bash
 [172.17.0.1]$ echo -Dconductr.agent.ip=$(hostname) | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini
 [172.17.0.1]$ echo --core-node $(hostname):9004 | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini
-```
-
-By default ConductR Agent and ConductR Core are using `/tmp` as its working directory. Since both ConductR Agent and ConductR Core are installed in the same machine, move the ConductR Agent working directory as such:
-
-```bash
-[172.17.0.1]$ echo -Dconductr.agent.storage-dir=/tmp/conductr-agent/bundles | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini
-[172.17.0.1]$ echo -Dconductr.agent.bundle-pidfile-dir=/tmp/conductr-agent/bundles/pids | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini
 ```
 
 Once configured, restart the ConductR Agent service.


### PR DESCRIPTION
- ConductR Core and Agent now creates its own work directory as part of startup
- Changes to configuration reference for ConductR Core - work directory now is located at tmpDir/conductr
- Changes to configuration reference for ConductR Agent - work directory now is located at tmpDir/conductr-agent
- Modify HAProxy reload script installation as the actual script will be provided by the ConductR HAproxy bundle
