### PR TITLE
CLI changes and bug fixes

### DIFF
--- a/src/main/play-doc/developer/DevQuickStart.md
+++ b/src/main/play-doc/developer/DevQuickStart.md
@@ -39,7 +39,7 @@ The conductr-cli is used to communicate with the ConductR cluster.
 To use `sbt-conductr` for your project add the plugin to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.13")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.14")
 ```
 
 ## Signaling application state

--- a/src/main/play-doc/developer/SetupSbtConductr.md
+++ b/src/main/play-doc/developer/SetupSbtConductr.md
@@ -20,7 +20,7 @@ The conductr-cli is used to communicate with the ConductR cluster.
 Add sbt-conductr to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.13")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.14")
 ```
 
 This makes several commands available within sbt. We'll use these commands on the next pages.

--- a/src/main/play-doc/operation/CLI.md
+++ b/src/main/play-doc/operation/CLI.md
@@ -50,7 +50,7 @@ subcommands:
                         help for subcommands
     version             print version
     info                print bundle information
-    services            print service information
+    service-names       print service locator information
     load                load a bundle
     run                 run a bundle
     stop                stop a abundle
@@ -90,22 +90,9 @@ shazar ./visualizer-poll-interval.sh
 
 The configuration is now ready to be loaded along with a bundle. Configuration is always provided as the second param to the `conduct load` command.
 
-## Accessing services provided by bundles
+## Accessing the Visualizer
 
-Access to services in ConductR is proxied for high availability and load balancing. To list all the currently running services in the ConductR available via lookup execute the `conduct services` command. Running tasks without named endpoints are not listed.
-
-```bash
-conduct services --ip 172.17.0.1
-```
-
-You should see that there is one service called `visualizer` provided by the Visualizer bundle. Only executing bundles with service names will be listed.
-
-```bash
-SERVICE NAME  BUNDLE ID  BUNDLE NAME       STATUS
-visualizer    23391d4    visualizer        Running
-```
-
-To access Visualizer point your browser to any ConductR node and add the name of the service to the URL, e.g. `http://172.17.0.1:9999`. Alternatively, if you can only access ConductR nodes using SSH, create a SSH tunnel that tunnels local port from your machine to the Visualizer service `ssh -L 8080:172.17.0.1:9999 172.17.0.1` (don't forget to substitute the `172.17.0.1`) and then access Visualizer by pointing your browser to `http://localhost:9999`.
+Access to services in ConductR is proxied for high availability and load balancing. To access Visualizer point your browser to any ConductR node and use the URL, `http://172.17.0.1:9999`. Alternatively, if you can only access ConductR nodes using SSH, create a SSH tunnel that tunnels local port from your machine to the Visualizer service `ssh -L 8080:172.17.0.1:9999 172.17.0.1` (don't forget to substitute the `172.17.0.1`) and then access Visualizer by pointing your browser to `http://localhost:9999`.
 
 Visualizer shows ConductR nodes as small blue circles with IP addresses next to them. Green circles denote bundles, and spinning circle means that a bundle is running. You should see one instance of bundle running. Try starting Visualizer on more nodes by executing:
 

--- a/src/main/play-doc/operation/ClusterSetupConsiderations.md
+++ b/src/main/play-doc/operation/ClusterSetupConsiderations.md
@@ -33,5 +33,3 @@ It is generally preferred to expose as few ports as required into the cluster fr
 We'll also generally use few edge routers. Management of the deployment, from TLS certificates, to DNS and other domain specific functions can provide compelling reason to deploy over multiple edge routers. For example, an ELB for `domain1` and another ELB for `domain2`.
 
 Differentiation of bundle location by path is particularly useful in larger systems wishing to expose fewer hostnames. Developers should note the ability to [preserve paths](CreatingBundles#Preserving-paths-at-the-proxy) at the proxy when applications require such.
-
-Use the `conduct services` command from the [[ConductR CLI|CLI]] to see what host name or port and path currently deployed bundles provide.


### PR DESCRIPTION
Changes to accomodate the renaming of "conduct services" to "conduct service-names", and also the latest release of the sbt-conductr plugin.