### PR TITLE
Updates from review

### DIFF
--- a/src/main/play-doc/developer/AkkaAndPlay.md
+++ b/src/main/play-doc/developer/AkkaAndPlay.md
@@ -125,9 +125,9 @@ In the above, no declaration of `services` is required as akka remoting is an in
 
 As a subscriber to the Lightbend Reactive Platform you can use SBR as an automated downing mechanism. Note that when using SBR you must handle the `MemberRemoved` event if it is received for the current member - SBR will not shutdown your application/service automatically.
 
-We recommend running ConductR's agents on separate machines to your ConductR core services. This will eliminate the potential for contention between the downing strategies of your application/service and that of ConductR's.
+We recommend running ConductR's agents on separate machines to your ConductR core services. This will eliminate the potential for contention between the downing strategies of your application/service and that of ConductR.
 
-If you prefer to run the ConductR agent on the same machine as ConductR core, contending strategies may not be a problem depending on your application/service's availability requirements. Suppose that your application/service chooses "keep oldest" as a strategy, and that the oldest member is in the minority portion of ConductR's cluster. If ConductR's SBR's "keep majority" decides to shutdown your oldest member, it will re-schedule it for execution again, but in the majority side of the cluster. In the case of "keep-oldest" resulting in reducing the number of running instances to one, your system may suffer an outage in terms of the length of time it takes ConductR to reschedule it for execution on the majority side of the cluster (seconds). This problem can be further mitigated by using an SBR timeout for "keep oldest" that is greater than ConductR's. 
+If you prefer to run the ConductR agent on the same machine as ConductR core, contending strategies may not be a problem depending on your application/service's availability requirements. Suppose that your application/service chooses "keep oldest" as a strategy, and that the oldest member is in the minority portion of ConductR's cluster. If ConductR's SBR's "keep majority" decides to shutdown your oldest member, it will re-schedule it for execution again, but in the majority side of the cluster. In the case of "keep-oldest" resulting in reducing the number of running instances to one, your system may suffer an outage in terms of the length of time it takes ConductR to reschedule it for execution on the majority side of the cluster (seconds). This problem can be further mitigated by using an SBR timeout for "keep oldest" that is greater than ConductR's.
 
 A reasonable start point when considering an SBR based strategy to use in conjunction with ConductR in general is to use the following configuration:
 
@@ -196,7 +196,7 @@ The Play flavors of conductr-bundle-lib automatically signal that your applicati
 play.modules.disabled += "com.typesafe.conductr.bundlelib.play.api.ConductRLifecycleModule"
 ```
 
-`play.modules.enabled` is used correspondly to declare your custom lifecycle module.
+`play.modules.enabled` is used correspondingly to declare your custom lifecycle module.
 
 A common use-case when using Akka clustering with your Play application is to wait until a cluster is ready. In this case your lifecycle module should then subscribe to member up and signal to the `StatusService` within the handler:
 
@@ -287,7 +287,7 @@ import com.typesafe.conductr.bundlelib.akka.{ Env => AkkaEnv }
 import com.typesafe.conductr.bundlelib.play.{ Env => PlayEnv }
 
 object Global extends GlobalSettings {
-  val totalConfiguration = 
+  val totalConfiguration =
     super.configuration ++ Configuration(AkkaEnv.asConfig) ++ Configuration(PlayEnv.asConfig)
 
   override def configuration: Configuration =
@@ -303,7 +303,7 @@ In the case of Play 2.4, the Play flavors of conductr-bundle-lib automatically s
 play.modules.disabled += "com.typesafe.conductr.bundlelib.play.api.ConductRLifecycleModule"
 ```
 
-`play.modules.enabled` is used correspondly to declare your custom lifecycle module.
+`play.modules.enabled` is used correspondingly to declare your custom lifecycle module.
 
 A common use-case when using Akka clustering with your Play application is to wait until a cluster is ready. In this case your lifecycle module should then subscribe to member up and signal to the `StatusService` within the handler:
 
@@ -339,7 +339,7 @@ The Lagom flavors of conductr-bundle-lib automatically signal that your applicat
 play.modules.disabled += "com.typesafe.conductr.bundlelib.play.api.ConductRLifecycleModule"
 ```
 
-`play.modules.enabled` is used correspondly to declare your custom lifecycle module.
+`play.modules.enabled` is used correspondingly to declare your custom lifecycle module.
 
 A common use-case when using Akka clustering with your Play application is to wait until a cluster is ready. In this case your lifecycle module should then subscribe to member up and signal to the `StatusService` within the handler:
 

--- a/src/main/play-doc/developer/BundleConfiguration.md
+++ b/src/main/play-doc/developer/BundleConfiguration.md
@@ -47,7 +47,7 @@ The following table describes each property:
 Name                 | Description
 ---------------------|-------------
 bind-port			 | Discussed [below](#Endpoints).
-compatibilityVersion | A versioning scheme that will be included in a bundle's name that describes the level of compatibility with bundles that go before it. By default we take the major version component of a version as defined by [http://semver.org/]. However you can make this mean anything that you need it to mean in relation to bundles produced prior to it. We take the notion of a compatibility version from [http://ometer.com/parallel.html].
+compatibilityVersion | A versioning scheme that will be included in a bundle's name that describes the level of compatibility with bundles that go before it. By default we take the major version component of a version as defined by <http://semver.org/>. However you can make this mean anything that you need it to mean in relation to bundles produced prior to it. We take the notion of a compatibility version from <http://ometer.com/parallel.html>.
 components			 | Each bundle has at least one component, and generally just one. A bundle component contains all that is required to run itself in terms of its directory on disk when the bundle is expanded. This section describes the meta data required for each bundle component.
 description			 | A human readable description of the bundle component.
 diskSpace            | The amount of disk space required to host an expanded bundle and configuration.

--- a/src/main/play-doc/developer/ConductrSandbox.md
+++ b/src/main/play-doc/developer/ConductrSandbox.md
@@ -1,6 +1,6 @@
 # Managing ConductR sandbox cluster
 
-sbt-conductr is using the ConductR sandbox image to spin up a local ConductR cluster. This is a docker image based on Ubuntu that includes ConductR which makes it simple to use ConductR in a development context. It can be also utilized by Continuous Integration (CI) and other automation to validate bundles within a cluster context. The sandbox is available to freely all developers.
+sbt-conductr is using the ConductR sandbox image to spin up a local ConductR cluster. This is a docker image based on Ubuntu that includes ConductR which makes it simple to use ConductR in a development context. It can be also utilized by Continuous Integration (CI) and other automation to validate bundles within a cluster context. The sandbox is available freely to all developers.
 
 > The docker image contains the full version of ConductR. However, it is not recommended to use this version in production because it is pre-configured for non production scenarios and because this ConductR version is started inside a Docker container.
 
@@ -23,7 +23,7 @@ Given the above you will then have a ConductR process running in the background 
 ### ConductR features
 
 The sandbox contains handy features which can be optionally enabled during startup by specifying the `--feature` option, e.g.:
-    
+
 ```scala
 [my-app] sandbox run <CONDUCTR_VERSION> --feature visualization
 [info] Running ConductR...

--- a/src/main/play-doc/developer/CreatingBundles.md
+++ b/src/main/play-doc/developer/CreatingBundles.md
@@ -19,7 +19,7 @@ Note that the description here is just to provide a feel of how `sbt-conductr` i
 lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
 ```
 
-Note that Lagom or Play user can enable one of the following plugins instead:
+Note that Lagom or Play users can enable one of the following plugins instead:
 
 | Project            | Description                                                                         |
 |--------------------|-------------------------------------------------------------------------------------|
@@ -30,7 +30,7 @@ Note that Lagom or Play user can enable one of the following plugins instead:
 | Play Java 2.4+     | `lazy val root = (project in file(".")).enablePlugins(PlayJava)`                    |
 | Play Java 2.3      | `lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging, PlayJava)`  |
 
-You will then need to declare what are known as "scheduling parameters" for ConductR. These parameters effectively describe what resources are used by your application or service and are used to determine which machine they will run on. 
+You will then need to declare what are known as "scheduling parameters" for ConductR. These parameters effectively describe what resources are used by your application or service and are used to determine which machine they will run on.
 
 The Play and Lagom bundle plugins provide [default scheduling parameters](https://github.com/typesafehub/sbt-conductr/blob/master/README.md#scheduling-parameters), i.e. it is not mandatory to declare scheduling parameters for these kind of applications. However, we recommend to define custom settings for each of your application.  
 
@@ -47,7 +47,7 @@ javaOptions in Universal := Seq(
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 128.MiB
 BundleKeys.diskSpace := 5.MB
-``` 
+```
 
 You'll note that the international standards for supporting [binary prefixes](http://en.wikipedia.org/wiki/Binary_prefix), as in `MiB`, is supported.
 
@@ -67,7 +67,7 @@ i.e. the name of your project (`visualizer`), its version `1.1` and the hash val
 
 Your bundle is now ready for loading into ConductR. What happened there is a few sensible defaults were chosen for you, a `bundle.conf` was generated, and a zip was built containing the output of a Universal build. The plugin then generated a [secure hash](http://en.wikipedia.org/wiki/Secure_Hash_Algorithm) of the zip contents and encoded it in the filename. The secure hash provides a version of your bundle that ConductR is able to verify and thus assure you of its integrity. You can derive a reasonable level of confidence that version xyz of your application or service is always going to be xyz; something that makes you happy if you ever need to reliably rollback to an older version of your software!
 
-Your application or service must be told what interface and port it should bind to when it runs. The Lagom and Play bundle plugins do that automatically. 
+Your application or service must be told what interface and port it should bind to when it runs. The Lagom and Play bundle plugins do that automatically.
 
 ConductR provides a specific ip address for the application to bind. Binding the provided private address enables the application to limit its network exposure to only the required interface. Furthermore, the port that ConductR provides for binding to is guaranteed to not clash with other bundle components on the same machine, and so it is important to use.
 
@@ -109,9 +109,9 @@ Http(system).bind(ip, port) // ... and so forth
 
 ### More on memory
 
-The javaOptions values declare the maximum and minimum heap size for your application respectively. Profiling your application under load will help you determine an optimal heap size. We recommend declaring the BundleKeys.memory value to be approximately twice that of the heap size. BundleKeys.memory represents the resident memory size of your application, which includes the heap, thread stacks, code caches, the code itself and so forth. On Unix, use the top command and observe the resident memory column (RES) with your application under load.
+The `javaOptions` values declare the maximum and minimum heap size for your application respectively. Profiling your application under load will help you determine an optimal heap size. We recommend declaring the `BundleKeys.memory` value to be approximately twice that of the heap size. `BundleKeys.memory` represents the resident memory size of your application, which includes the heap, thread stacks, code caches, the code itself and so forth. On Unix, use the top command and observe the resident memory column (RES) with your application under load.
 
-BundleKeys.memory is used for locating machines with enough resources to run your application, and so it is particularly important to size it before you go to production.
+`BundleKeys.memory` is used for locating machines with enough resources to run your application, and so it is particularly important to size it before you go to production.
 
 ## Docker bundles
 

--- a/src/main/play-doc/general/ConductrTerms.md
+++ b/src/main/play-doc/general/ConductrTerms.md
@@ -8,6 +8,6 @@ Bundle      | A bundle is an archive of components along with meta data (a bundl
 Component   | A bundle can have many components although it typically has just one. A component in Lightbend ConductR represents a unit of software that  describes what will become a process when a bundle is started.
 Configuration | Configuration alters a component's behavior at runtime and may declare the location of a database, credentials, logging file levels and so forth. Configuration is primarily sourced from within a bundle's components. In addition external configuration may be applied across all of a bundle's components when a bundle is loaded. This additional configuration would typically relate to values for production, testing and so forth.
 Core        | The ConductR scheduler
-Developer   | Developers who develop using Scala/Java, Akka, Play and/or other Typesafe technologies.
+Developer   | Developers who develop using Scala/Java, Akka, Play and/or other Lightbend technologies.
 Operator    | Targets the "linux admins" of the Ops world and covers both IT Ops and Dev Ops style roles.
 Service     | An Application can be broken down into logical services, comprised of generalised services or not even have services. What constitutes a service is left to the Developer. Lightbend ConductR recognises the aggregation of bundles through a "system" attribute assigned to the bundle. This attribute can be used by a component to associate itself with an Akka cluster (for example).

--- a/src/main/play-doc/general/MigrationGuide.md
+++ b/src/main/play-doc/general/MigrationGuide.md
@@ -36,7 +36,7 @@ conductr-haproxy is now provided as a bundle with the "haproxy" role. When runni
 
 ### Amazon's ELB
 
-Prior to 1.2, we recommended that you configure the ELB to poll the /bundles endpoint of the control protocol. Given conductr-haproxy you should now configured the ELB to poll the http://:9009/status. This endpoint will return an HTTP OK status when HAProxy has been correctly configured therefore leading to a more reliable configuration of the ELB. See [the cluster setup considerations document](ClusterSetupConsiderations#Cluster security considerations) for more information.
+Prior to 1.2, we recommended that you configure the ELB to poll the /bundles endpoint of the control protocol. Given conductr-haproxy you should now configured the ELB to poll the http://:9009/status. This endpoint will return an HTTP OK status when HAProxy has been correctly configured therefore leading to a more reliable configuration of the ELB. See [the cluster setup considerations document](ClusterSetupConsiderations#Cluster-security-considerations) for more information.
 
 ## Syslog
 

--- a/src/main/play-doc/general/MigrationGuide.md
+++ b/src/main/play-doc/general/MigrationGuide.md
@@ -24,11 +24,11 @@ ConductR Core holds the state of the cluster, and is responsible for decision ma
 
 ConductR Agent is responsible for running bundle processes. As such, the bundle roles which are previously specified are now to be specified within ConductR Agent.
 
-The ConductR Core and ConductR Agent is available as 2 different packages. The [[installation instructions|Install]] describes the steps of installing ConductR Core and ConductR Agent on the same host. These steps is also applicable should ConductR Core and ConductR Agent installation on different host is desired.
+The ConductR Core and ConductR Agent is available as 2 different packages. The [[installation instructions|Install]] describes the steps of installing ConductR Core and ConductR Agent on the same host. These steps are also applicable should ConductR Core and ConductR Agent installation on different hosts be desired.
 
 ## Node Peer Access
 
-This distributed topology enables Agents to be managed by remote Cores. This requires nodes to be able to reach each other on ports 2552, 9005, 9007 and 9008 in addition the 9004 and 9006 ports previously required with 1.1. See also the port table in [[Subnets and Security Groups|Install#Subnets-and-Security-Groups]].
+This distributed topology enables Agents to be managed by remote Cores. This requires nodes to be able to reach each other on ports 2552, 9005, 9007 and 9008 in addition to the 9004 and 9006 ports previously required with 1.1. See also the port table in [[Subnets and Security Groups|Install#Subnets-and-Security-Groups]].
 
 ## Proxying
 
@@ -45,7 +45,7 @@ In additional to disabling Elasticsearch via configuration, a service lookup mus
 ```
   -Dcontrail.syslog.server.host=127.0.0.1
   -Dcontrail.syslog.server.port=514
-  -Dcontrail.syslog.server.elasticsearch.enabled=off 
+  -Dcontrail.syslog.server.elasticsearch.enabled=off
   -Dcontrail.syslog.server.service-locator.enabled=off
 ```
 

--- a/src/main/play-doc/general/Overview.md
+++ b/src/main/play-doc/general/Overview.md
@@ -32,7 +32,7 @@ Lightbend ConductR fundamentally consists of the _ConductR_ process; an applicat
 
 Many types of client are possible given HTTP/REST/JSON. For developers, an sbt plugin named `sbt-conductr` provides control protocol commands (load, unload, start etc.) for managing the lifecycle of bundles. Similarly for operators, a set of command line tools are provided and can be run on Windows and Unix style environments.
 
-Again for developers, [Typesafe Activator](http://lightbend.com/activator) can also communicate with Lightbend ConductR. Activator communicates with sbt via the sbt-server protocol and so all tasks and settings available to the sbt-conductr plugin will be available to Activator. Therefore Activator can be used to prepare bundles and publish them to the cluster, or on a local machine for testing.
+Again for developers, [Lightbend Activator](http://lightbend.com/activator) can also communicate with Lightbend ConductR. Activator communicates with sbt via the sbt-server protocol and so all tasks and settings available to the sbt-conductr plugin will be available to Activator. Therefore Activator can be used to prepare bundles and publish them to the cluster, or on a local machine for testing.
 
 ### Bundles
 

--- a/src/main/play-doc/general/ReleaseNotes.md
+++ b/src/main/play-doc/general/ReleaseNotes.md
@@ -12,7 +12,7 @@ When using 2.0 it is important that you revisit your bundle's cpu and memory set
 
 1. Improvements to Mesos reconciliation.
 2. Service names are now optional for bundles (a service doesn't always require being located).
-3. A drammatic improvement in performance has been made given that ConductR's executor is no longer consider when accepting resource offers. This should lead to being able to run more bundles within a Mesos system and seeing that offers are accepted quickly.
+3. A dramatic improvement in performance has been made given that ConductR's executor is no longer considered when accepting resource offers. This should lead to being able to run more bundles within a Mesos system and seeing that offers are accepted quickly.
 
 ## 2.0.0-beta.3 October 12th, 2016
 
@@ -24,16 +24,16 @@ When using 2.0 it is important that you revisit your bundle's cpu and memory set
 6. The Visualizer has been improved to represent agent information.
 7. The Visualizer is now available as the web ui of the ConductR service from within the DC/OS UI.
 8. The control protocol is now available via the DC/OS admin gateway.
-9. Completely refreshed ConductR's dependencies including the Akka 2.4.10 and its corresponding Akka http release (the latter having some significant performance improvements).
+9. Completely refreshed ConductR's dependencies including the Akka 2.4.10 and its corresponding Akka HTTP release (the latter having some significant performance improvements).
 10. The /members/events endpoint now emits events representing the Akka cluster Reachable and Unreachable states.
 11. A major fix to the handling of multipart form data when loading a bundle has been made. Prior to this bundle load operations could fail sporadically.
-12. A problem was fixed whereby a bundle could start and then quickly stop. This was due to a race condition that could occur intermitently.
+12. A problem was fixed whereby a bundle could start and then quickly stop. This was due to a race condition that could occur intermittently.
 13. A ConductR agent (Mesos executor) now requests 1.9 CPU allocations in order to improve performance.
 
 ## 2.0.0-beta.2 September 21st, 2016
 
 1. The sandbox logs have been improved such that they are not confused with the logging associated with the bootstrap's initialization.
-2. fixes a problematic startup sequence for the sandbox where the "feature" bundles could miss being scaled up due to an agent not being available initially.
+2. Fixes a problematic startup sequence for the sandbox where the "feature" bundles could miss being scaled up due to an agent not being available initially.
 3. ConductR Agent ports are now reserved on Mesos hosts.
 4. ConductR Agents are now periodically reconciled with ConductR Core's view of the world, and bundles are handled in the case of reconciliation failure.
 5. V1 of the ConductR control protocol has now been removed (now only V2 is supported - you will want to update your CLI and sbt-conductr versions)

--- a/src/main/play-doc/operation/ConfigurationRef.md
+++ b/src/main/play-doc/operation/ConfigurationRef.md
@@ -160,7 +160,7 @@ conductr {
   # The directory where bundles and their configuration are written to.
   storage-dir = ${java.io.tmpdir}/conductr/bundles
 
-  # The amount of time Typesafe ConductR expects to wait on achieving a read quorum. 10 seconds should
+  # The amount of time Lightbend ConductR expects to wait on achieving a read quorum. 10 seconds should
   # cover large clusters, but you may need to increase this if read timeouts appear
   # frequently in your log files.
   read-quorum-timeout = 10 seconds
@@ -219,8 +219,8 @@ conductr {
     # The amount of time to wait on obtaining state events publisher.
     state-events-timeout = 5 seconds
 
-    # The amount of time to wait on uploading a bundle into Typesafe ConductR. This timeout will vary depending
-    # on how long it takes for clients of Typesafe ConductR to upload bundles i.e. the WAN will dictate this
+    # The amount of time to wait on uploading a bundle into Lightbend ConductR. This timeout will vary depending
+    # on how long it takes for clients of Lightbend ConductR to upload bundles i.e. the WAN will dictate this
     # parameter. If you find that clients e.g. the CLI, are reporting timeouts then try increasing
     # this parameter.
     load-scheduler-timeout = 1 minute

--- a/src/main/play-doc/operation/DynamicProxyConfiguration.md
+++ b/src/main/play-doc/operation/DynamicProxyConfiguration.md
@@ -568,7 +568,7 @@ The proxy will only be configured for endpoints from the bundles which are runni
 
 Review the ACL configuration of the endpoints deployed in the ConductR cluster. Use the command `conduct acls http` and `conduct acls tcp` to display request ACLs for HTTP and TCP traffic respectively.
 
-The command will provide a warning message should duplicate endpoints are detected. Refer to [Requirement](#Requirement) section for more details on duplicate endpoints.
+The command will provide a warning message if duplicate endpoints are detected. Refer to [Requirement](#Requirement) section for more details on duplicate endpoints.
 
 ### Check the logs from ConductR HAProxy bundle
 

--- a/src/main/play-doc/operation/Install.md
+++ b/src/main/play-doc/operation/Install.md
@@ -731,7 +731,7 @@ ID                 NAME                           #REP  #STR  #RUN
 
 ## Installing a Proxy on Ubuntu
 
-> Skip the next section and scroll down to ["Installing a Proxy on CoreOS"](#Installing_a_Proxy_on_CoreOS) when using CloudFormation.
+> Skip the next section and scroll down to ["Installing a Proxy on CoreOS"](#Installing-a-Proxy-on-CoreOS) when using CloudFormation.
 
 _Perform each step in this section on all public nodes. For full resilience a proxy should be installed for each public node machine. The public node machines are machines assigned with `slave_public` role._
 

--- a/src/main/play-doc/operation/Install.md
+++ b/src/main/play-doc/operation/Install.md
@@ -706,7 +706,7 @@ Obtain the ConductR's application definition JSON.
 
 In `Services`, post the JSON file to deploy the ConductR Service. This can be done using json mode of the 'Deploy New Service' dialog. Refer to DC/OS documentation for deployment steps given the application definition JSON.
 
-By default ConductR will be deployed with a single core scheduler instance. Upon startup ConductR will launch its agent executor process on each of the available Mesos slave nodes.
+By default ConductR will be deployed with a single core scheduler instance. Upon startup ConductR will launch its agent executor process on each of the available Mesos agent nodes.
 
 Wait until the ConductR instance's health to marked as healthy before proceeding.
 

--- a/src/main/play-doc/operation/Install.md
+++ b/src/main/play-doc/operation/Install.md
@@ -40,7 +40,7 @@ echo "JAVA_HOME=/usr/lib/jvm/java-8-oracle" | sudo tee -a /etc/environment
 
 ## Installing ConductR on the first machine
 
-ConductR comprises of the ConductR Core and ConductR Agent. ConductR Core is responsible for cluster-wide scaling and replication decision making, as well as hosting the application files or the bundles. ConductR Agent is responsible for executing the application processes. The ConductR Core and the ConductR Agent are ran as separate processes, and hence separate services within the operating system.
+ConductR comprises of the ConductR Core and ConductR Agent. ConductR Core is responsible for cluster-wide scaling and replication decision making, as well as hosting the application files or the bundles. ConductR Agent is responsible for executing the application processes. The ConductR Core and the ConductR Agent are run as separate processes, and hence separate services within the operating system.
 
 This tutorial uses three systems with the addresses `172.17.0.{1,2,3}`. To simplify the installation and configuration instructions, we are going to use the hostname command. Please ensure the hostname is set correctly or substitute your addresses as appropriate for $(hostname). To set the hostname, pass the ip address to hostname.
 
@@ -349,11 +349,11 @@ Prior to using the Ansible playbooks to create your cluster, you will needs the 
 
 ## Ansible Instructions
 
-The [ConductR-Ansible](https://github.com/typesafehub/conductr-ansible) plays and playbooks provision [Lightbend ConductR](https://conductr.lightbend.com) cluster nodes in AWS EC2 using [Ansible](http://www.ansible.com). The branchs of The [ConductR-Ansible](https://github.com/typesafehub/conductr-ansible) plays and playbooks provision [Lightbend ConductR](https://conductr.lightbend.com) cluster nodes in AWS EC2 using [Ansible](http://www.ansible.com). The branches of track that of ConductR. As such the 2.0.x branch of ConductR-Ansible would be used to build ConductR 2.0.x clusters.
+The [ConductR-Ansible](https://github.com/typesafehub/conductr-ansible) plays and playbooks provision [Lightbend ConductR](https://conductr.lightbend.com) cluster nodes in AWS EC2 using [Ansible](http://www.ansible.com). The branches of the repository track that of ConductR. As such the 2.0.x branch of ConductR-Ansible would be used to build ConductR 2.0.x clusters.
 
 Use create-network-ec2.yml to setup a new Virtual Private Cloud (VPC) and create your cluster in the new VPC. You only need to provide your access keys and what region to execute in. The playbook outputs a vars file for use with the build-cluster-ec.yml.
 
-The playbook build-cluster-ec2.yml launches three instances across three availability zones. ConductR Core and ConductR Agent is installed on all instances and configured to form a cluster. The nodes are registered with a load balancer. This playbook can be used with the newly created VPC from create-network-ec2.yml or your existing VPC and security groups.
+The playbook build-cluster-ec2.yml launches three instances across three availability zones. ConductR Core and ConductR Agent are installed on all instances and configured to form a cluster. The nodes are registered with a load balancer. This playbook can be used with the newly created VPC from create-network-ec2.yml or your existing VPC and security groups.
 
 ### Prepare controller host
 
@@ -398,7 +398,7 @@ Your controller host is now ready to run plays.
 
 ### Create network
 
-ConductR-Ansible can create and prepare a new VPC for use with ConductR. Running ConductR in it's own VPC isolates the cluster from the rest of your EC2 network. If you have existing services in EC2 that ConductR needs to be able to access on the local network using an EC2 private ip address, you need to use your existing VPC. In all other cases, creating a ConductR VPC is recommended, but is not required if you are comfortabling setting up the network yourself.
+ConductR-Ansible can create and prepare a new VPC for use with ConductR. Running ConductR in its own VPC isolates the cluster from the rest of your EC2 network. If you have existing services in EC2 that ConductR needs to be able to access on the local network using an EC2 private ip address, you need to use your existing VPC. In all other cases, creating a ConductR VPC is recommended, but is not required if you are comfortabling setting up the network yourself.
 
 ```bash
 ansible-playbook create-network-ec2.yml
@@ -430,7 +430,7 @@ ansible-playbook build-cluster-ec2.yml -e "VARS_FILE=vars/{{EC2_REGION}}_vars.ym
 
 If the playbook completes successfully, you will have a three node cluster that can be accessed using the ELB DNS name. ConductR comes with a `visualizer` sample application. The playbook created ELB includes a listener mapping port 80 to Visualizer's port 9999 port mapping.
 
-Head over to the next section [[Managing application|ManagingApplication]] to learn how to deploy visualizer application to your fresh ConductR cluster. You can ssh into one of the cluster nodes using it's public ip address to deploy Visualizer. Use the username from the `REMOTE_USER` (currently "ubuntu") and the PEM file as for the identify file (-i). The ConductR CLI has been installed to all nodes for you. Once deployed, you can view the Visualizer via port 80 using the ELB DNS name in your browser.
+Head over to the next section [[Managing application|ManagingApplication]] to learn how to deploy the visualizer application to your fresh ConductR cluster. You can ssh into one of the cluster nodes using its public ip address to deploy Visualizer. Use the username from the `REMOTE_USER` (currently "ubuntu") and the PEM file as for the identify file (-i). The ConductR CLI has been installed to all nodes for you. Once deployed, you can view the Visualizer via port 80 using the ELB DNS name in your browser.
 
 Re-running this playbook launches a new set of instances. This means it can be re-run to create additional ConductR clusters. For example we might re-run the playbook to create a new cluster using a new version of ConductR to test new features. If we change only the values of `CONDUCTR_PKG`, `CONDUCTR_AGENT_PKG`, and `ELB` in the vars file to a new ConductR version package and new ELB, running the playbook again will create a new cluster using the new version in the same subnets as the previous version.
 
@@ -708,7 +708,7 @@ In `Services`, post the JSON file to deploy the ConductR Service. This can be do
 
 By default ConductR will be deployed with a single core scheduler instance. Upon startup ConductR will launch its agent executor process on each of the available Mesos agent nodes.
 
-Wait until the ConductR instance's health to marked as healthy before proceeding.
+Wait until the ConductR instance's health is marked as healthy before proceeding.
 
 If more instances are required, scale ConductR to the desired total schedulers using the `Instances` within `Edit Service` not the `Scale` dialog. Ensure that all of the instances are healthy before proceeding. Multiple core schedulers are recommended for resilience however schedulers are not required on all nodes.
 

--- a/src/main/play-doc/operation/ManageServices.md
+++ b/src/main/play-doc/operation/ManageServices.md
@@ -100,7 +100,7 @@ To perform a per node upgrade for ConductR Agent, connect the new agent node to 
 
 To perform a per node upgrade for ConductR Core and ConductR Agent installed on the same host, connect both the ConductR Core and ConductR agent to an existing cluster. As old hosts (containing both old ConductR Core and ConductR Agent) are removed from the cluster, bundles will be replicated to the new resources, and bundles will be rescheduled for execution on the new agent nodes.
 
-It is critical to allow sufficient time for bundle relocation and replication before removing old members. In addition to ConductR replicating bundles to new nodes, stateful bundles may require additional time to replicate application data. Removing an agent node before application data has fully replicated can result in application data loss. Elasticsearch bundle provided along with ConductR, for example, requires [verification](#Elasticsearch Verification) to ensure the data is transferred into the new agent node.
+It is critical to allow sufficient time for bundle relocation and replication before removing old members. In addition to ConductR replicating bundles to new nodes, stateful bundles may require additional time to replicate application data. Removing an agent node before application data has fully replicated can result in application data loss. Elasticsearch bundle provided along with ConductR, for example, requires [verification](#Elasticsearch-Verification) to ensure the data is transferred into the new agent node.
 
 Application specific data replication should also be monitored during an upgrade to prevent data loss.
 

--- a/src/main/play-doc/operation/ManageServices.md
+++ b/src/main/play-doc/operation/ManageServices.md
@@ -52,7 +52,7 @@ echo -Dakka.cluster.roles.0=megaIOPS | sudo tee -a /usr/share/conductr-agent/con
 echo -Dakka.cluster.roles.1=muchMem | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini
 sudo service conductr-agent restart
 ```
- 
+
 With this setting the node would offer the roles `megaIOPS` and `muchMem`. Only bundles with a `BundleKeys.roles` of `megaIOPS,` `muchMem` or both `megaIOPS` and `muchMem` will be loaded and run on this node.
 
 The ConductR Agent service must be restarted for changes to this file to take effect.
@@ -80,7 +80,7 @@ Larger clusters on the other hand will generally want more specialization and th
 
 ## Service Monitoring
 
-For best resilience, the ConductR service daemons should be monitored and restarted in the event of failure. [sbt-native-packager](https://github.com/sbt/sbt-native-packager) has experimental [systemd support](http://www.scala-sbt.org/sbt-native-packager/archetypes/java_server/customize.html#systemd-support). As systemd support matures, ConductR will made available as a package manged by systemd with restart on failure enabled. Until that time, third party daemon monitors can be utilized to provide restart on failure.
+For best resilience, the ConductR service daemons should be monitored and restarted in the event of failure. [sbt-native-packager](https://github.com/sbt/sbt-native-packager) has experimental [systemd support](http://www.scala-sbt.org/sbt-native-packager/archetypes/java_server/customize.html#systemd-support). As systemd support matures, ConductR will be made available as a package managed by systemd with restart on failure enabled. Until that time, third party daemon monitors can be utilized to provide restart on failure.
 
 # Upgrading ConductR
 
@@ -98,7 +98,7 @@ To perform a per node upgrade for ConductR Core, introduce new cluster members t
 
 To perform a per node upgrade for ConductR Agent, connect the new agent node to an existing cluster. As old agent nodes are removed from the cluster, bundles will be rescheduled for execution on the new agent nodes.
 
-To perform a per node upgrade for ConductR Core and ConductR Agent installed on the same host, connect both the ConductR Core and ConductR agent to an existing cluster. As old host (containing both old ConductR Core and ConductR Agent) are removed from the cluster, bundles will be replicated to the new resources, and bundles will be rescheduled for execution on the new agent nodes.
+To perform a per node upgrade for ConductR Core and ConductR Agent installed on the same host, connect both the ConductR Core and ConductR agent to an existing cluster. As old hosts (containing both old ConductR Core and ConductR Agent) are removed from the cluster, bundles will be replicated to the new resources, and bundles will be rescheduled for execution on the new agent nodes.
 
 It is critical to allow sufficient time for bundle relocation and replication before removing old members. In addition to ConductR replicating bundles to new nodes, stateful bundles may require additional time to replicate application data. Removing an agent node before application data has fully replicated can result in application data loss. Elasticsearch bundle provided along with ConductR, for example, requires [verification](#Elasticsearch Verification) to ensure the data is transferred into the new agent node.
 
@@ -138,7 +138,7 @@ Once these steps has been performed with successful result, Elasticsearch cluste
 
 ## Recovering from Red Elasticsearch Cluster
 
-Should Elasticsearch cluster endpoint `status` has the `red` value, this means one or more shard has not been allocated to the member of the cluster.
+Should the Elasticsearch cluster endpoint `status` have the `red` value, this means one or more shards have not been allocated to the member of the cluster.
 
 The recovery process involves allocating the unassigned shards to the member of the cluster.
 
@@ -197,4 +197,4 @@ The shard `0` should now be allocated to the node called `Thin Man`. Repeat thes
 
 When allocating shards, ensure the shards are distributed as evenly as possible across all nodes of the Elasticsearch cluster. This will improve the resiliency of the cluster.
 
-Once all the shards has been reallocated, the cluster health endpoint `status` should be back to `green` and the Elasticsearch cluster should be back in a working order.
+Once all the shards have been reallocated, the cluster health endpoint `status` should be back to `green` and the Elasticsearch cluster should be back in a working order.


### PR DESCRIPTION
A couple of fixes from reviewing the ConductR docs:

 - Typesafe ConductR => Lightbend ConductR
 - Mesos uses "agent" instead of "slave" as of version 1.0
 - Several minor typos
 - Link fixes; untested since I didn't find instructions on how to render the docs locally
    (a few are also in https://github.com/jonas/conductr-doc/tree/link-fixes-1.1 for which I can create a PR if you want)
