### PR TITLE
Add lines for Docker configuration instructions to create Docker group and restart services.

### DIFF
--- a/src/main/play-doc/operation/Install.md
+++ b/src/main/play-doc/operation/Install.md
@@ -168,7 +168,10 @@ Similarly for ConductR Agent:
 ConductR supports running applications and services within Docker. If you plan on running Docker based bundles, you will need to install [Docker](https://docs.docker.com/) according to [the official documentation](https://docs.docker.com/installation/ubuntulinux/). Once Docker is installed then add the ConductR-Agent daemon user/group to the `docker` group so that it has [the correct permissions in order to access Docker](http://docs.docker.com/installation/ubuntulinux/#giving-non-root-access):
 
 ```bash
+[172.17.0.1]$ sudo groupadd docker
 [172.17.0.1]$ sudo usermod -a -G docker conductr-agent
+[172.17.0.1]$ sudo service docker restart
+[172.17.0.1]$ sudo conductr-agent restart
 ```
 
 ## Installing ConductR on the remaining machines


### PR DESCRIPTION
When I tried to run the usermod command kept failing for me initially. According to the Docker docs, you may need to add the Docker group. I also found it necessary to restart the Docker daemon as well as the Conductr-Agent service to ensure this change took place. The docs should reflect this.

Ref: https://docs.docker.com/engine/installation/linux/linux-postinstall/#/manage-docker-as-a-non-root-user