### PR TITLE
Update to sbt-conductr 2.2.4 (master)

### DIFF
--- a/src/main/play-doc/developer/DevQuickStart.md
+++ b/src/main/play-doc/developer/DevQuickStart.md
@@ -37,7 +37,7 @@ The conductr-cli is used to communicate with the ConductR cluster.
 To use `sbt-conductr` for your project add the plugin to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.20")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.2.4")
 ```
 
 ## Signaling application state

--- a/src/main/play-doc/developer/SetupSbtConductr.md
+++ b/src/main/play-doc/developer/SetupSbtConductr.md
@@ -8,7 +8,7 @@
 
 ## Prerequisites
 
-* [Docker](https://www.docker.com/)
+* [Docker](https://www.docker.com/) (when using Docker based bundles)
 * [conductr-cli](CLI#New-CLI-installation)
 
 The conductr-cli is used to communicate with the ConductR cluster. The CLI also includes a "developer sandbox" so that you may test your bundles in a production-like environment, but locally on your machine.
@@ -20,7 +20,7 @@ The conductr-cli is used to communicate with the ConductR cluster. The CLI also 
 Add sbt-conductr to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.20")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.2.4")
 ```
 
 This makes several commands available within sbt. We'll use these commands on the next pages.


### PR DESCRIPTION
- Update to sbt-conductr 2.2.4
- Make clear that Docker is only required for Docker based bundles.