### PR TITLE
Add documentation for CLI Basic Authentication (2.0)

### DIFF
--- a/src/main/play-doc/operation/CLI.md
+++ b/src/main/play-doc/operation/CLI.md
@@ -79,14 +79,16 @@ The CLI is able to integrate with the DC/OS CLI e.g. `dcos conduct info` will re
 
 ## HTTP Basic Authentication
 
-To enable HTTP Basic Authentication, provide the following settings file in the `~/.conductr/settings.conf`.
+> Note: From a cluster setup perspective, HTTP Basic Authentication for the ConductR CLI can be set up and enforced as described in the section [Securing the ConductR CLI with Basic Authentication](DynamicProxyConfiguration#Securing-the-ConductR-CLI-with-Basic-Authentication).
+
+To enable HTTP Basic Authentication on the ConductR CLI, provide the following settings file in the `~/.conductr/settings.conf`.
 
 ```
 conductr {
   auth {
     enabled  = true
     username = "steve"
-    password = "letmein"
+    password = "stevespassword"
   }
   server_ssl_verification_file = "/home/user/validate-server.pem"
 }
@@ -96,3 +98,40 @@ HTTP Basic Authentication is enabled if the flag `enabled` is set to `true`. Set
 Set the `username` and `password` accordingly. The `server_ssl_verification_file` points to an absolute path of the file used to validate the SSL cert of the server.
 
 If HTTP Basic Authentication is enabled then the CLI will send HTTP requests using HTTPS instead of HTTP.
+
+The `~/.conductr/settings.conf` file may also specify configurations for multiple clusters as shown below:
+
+```
+conductr {
+  auth {
+    "192.168.99.100" {
+      enabled  = true
+      username = "steve"
+      password = "stevespassword"
+      server_ssl_verification_file = "/home/user/validate-server.pem"
+    }
+    "192.168.99.200" {
+      enabled  = false
+    }
+  }
+}
+```
+
+In the above case, authentication credentials will be used when the ConductR CLI interacts with the cluster located at `192.168.99.100`, while the ConductR Core located at `192.168.99.200` will not require authentication. 
+
+With the above setting in place, the ConductR CLI can be used as normally: 
+
+```
+conduct info --host 192.168.99.100
+```
+
+If valid credentials are not found in ~/.conductr/settings.conf, the ConductR CLI will return a 401 Unauthorized error.
+
+## ConductR CLI on alternative ports
+
+If the ConductR Control Protocol is configurted to listen for requests on a port other than `9005`, the ConductR CLI can still be used by specifying the `--port` (-p) argument. For example, if we wanted to use the ConductR CLI within the cluster setup in the example described in [Securing the ConductR CLI with Basic Authentication](DynamicProxyConfiguration#Securing-the-ConductR-CLI-with-Basic-Authentication), we could access the Control Protocol directly using port `9055`:
+
+```
+conduct info --host 172.17.0.1 -p 9055
+```
+

--- a/src/main/play-doc/operation/ClusterSetupConsiderations.md
+++ b/src/main/play-doc/operation/ClusterSetupConsiderations.md
@@ -26,6 +26,8 @@ For EC2 deployments, the bastion host will be placed in a different security gro
 
 The bastion host can be also be used as the controller host for installation and maintenance. Deployment bundles can be uploaded to the bastion host from build servers to provide a final gated 'one command' deployment step to a continuous deployment pipeline.
 
+SSL and Basic Authentication may also be setup to further secure the [ConductR CLI](CLI) and [Control API](ControlAPI) from unauthorized access. This is particularly useful where a fully locked down bastion host is not viable, or bundle deployments need to be limited to certain authorized users. For example, if operating a cluster on an internal 'flat' network, it is desirable to ensure that only authorized users are allowed to deploy bundles. It can also be advantageous to limit who can deploy to different environments. For example, user A may be allowed to deploy to Staging and Prod, while user B should only be allowed to deploy to Staging. This is described in more detail in the section [Securing the ConductR CLI with Basic Authentication](DynamicProxyConfiguration#Securing-the-ConductR-CLI-with-Basic-Authentication).
+
 # Managing Ports and Paths
 
 It is generally preferred to expose as few ports as required into the cluster from the public network. Ports should be limited to `80` and `443` in general. Most all cluster bundles are thus differentiated on the internet by host name or path. Exceptions to this include internal service ports, e.g. `5444`.  These ports might be used for services only to be used internally, with an internal facing load balancer, that is not exposed to the internet.

--- a/src/main/play-doc/operation/DynamicProxyConfiguration.md
+++ b/src/main/play-doc/operation/DynamicProxyConfiguration.md
@@ -556,6 +556,83 @@ Here are the explanation for the example template above:
 * The `http-request auth realm kibana_users if !kibana_basic_auth` will trigger the HTTP basic auth prompt if the HTTP basic auth is not supplied with the request.
 * The example has list of users declared with insecure password. In the actual production scenario, consider using a `password` HAProxy directive which declares a secure password - refer to the [HAProxy](http://www.haproxy.org/) documentation for further details.
 
+### Securing the ConductR CLI with Basic Authentication
+
+HTTP Basic Authentication may be used to restrict access to a ConductR's [Control API](ControlAPI). The [ConductR CLI](CLI) uses the Control API to load bundles and retrieve cluster information, thus applying Basic Authentication against this service restricts who is allowed to load, start and stop bundles in the ConductR cluster. This provides another method of securing the cluster beyond security group and firewall restrictions. This is useful when a fully restricted [bastion host](https://en.wikipedia.org/wiki/Bastion_host) is not viable, or to further restrict access to particular clusters via the CLI. For example, while it may be acceptable to allow everyone on a team to deploy bundles to a development or staging cluster, a production cluster may require more restrictive access.
+
+As a prerequisite, the ConductR Core's Control Server should be configured to bind to a private IP address and an available port. By default, the Control Server will bind to the configured ConductR Core IP address and port `9005`. Binding to a different IP and/or port can be achieved by updating the configuration values `conductr.control-server.ip` and/or `conductr.control-server.port` respectively in `/usr/share/conductr/conf/conductr.ini`. For this example, we will assume the ConductR Core's IP address is private to the cluster but will bind the Control Server to `9055` internally to distinguish it from the external Control Protocol. Note that this change will be made on all ConductR Cores.
+
+```
+-Dconductr.control-server.port = 9055
+```
+
+Restart the ConductR Core Service with the following command:
+
+```
+> sudo service conductr restart
+```
+
+HAProxy must then be configured to provide Basic Authentication and SSL termination for the Control Protocol. In this case, it will still be accessed via the default port `9005` externally. 
+
+> An SSL certificate will need to be generated and installed on the HAProxy host to enable two-way authentication for HTTPS. [OpenSSL](https://www.openssl.org/) can be used for this. While there are lots of resources available online for creating certificates, the following script can be used to generate a self-signed certificate for **testing purposes only**. You will need to substitute the fields of the `openssl req` command with appropriate values for your server. It will create a folder called `ssl-conductr.cli` containing the certificates and a .pem file:
+
+```
+#!/bin/bash
+
+# Note - this script is for testing purposes only.
+
+set -e
+
+SCRIPT_DIR="$( cd "$(dirname $0)" && pwd)"
+CERT_NAME=ssl-"conductr.cli"
+SSL_CERT_DIR="$SCRIPT_DIR/$CERT_NAME"
+
+#rm $SSL_CERT_DIR/*
+mkdir -p $SSL_CERT_DIR
+
+echo "Generating SSL certs and keys into $SSL_CERT_DIR"
+openssl genrsa -out $SSL_CERT_DIR/$CERT_NAME.key 2048
+#This line creates the certificate - Most important fields are CN=.. and subjectAltName=... These are the domains that the cert can be used with. For the purposes of the ConductR CLI, this must cover the Cores at least.
+#For Dev servers, this would likely be (untested): *.ebiz.verizon.com
+openssl req -new -key $SSL_CERT_DIR/$CERT_NAME.key -sha256 -nodes -subj '/C=US/ST=California/L=San Francisco/O=Lightbend/OU=Prod Suite/CN=192.168.99.100/emailAddress=dev.null@lightbend.com' -out $SSL_CERT_DIR/$CERT_NAME.csr
+openssl x509 -req -days 365 -in $SSL_CERT_DIR/$CERT_NAME.csr -signkey $SSL_CERT_DIR/$CERT_NAME.key -out $SSL_CERT_DIR/$CERT_NAME.crt
+
+echo "Concat crt and key into pem file"
+cat $SSL_CERT_DIR/$CERT_NAME.crt $SSL_CERT_DIR/$CERT_NAME.key | tee $SSL_CERT_DIR/$CERT_NAME.pem
+```
+
+HAProxy is then configured with the path of our installed certificate and credentials to apply Basic Authentication to incoming ConductR Control API requests via port `9005`. To do this, we add the following to our custom HAProxy Configuration: 
+ - a frontend `ctrl_frontend_secure` to handle incoming Control API requests
+ - a userlist `ctrl_users`, which specifies acceptable users and passwords. 
+ 
+> While a plain text insecure password is shown below, HAProxy also supports secure (encrypted) passwords in userlists, which are recommended for production installations.
+   
+ - a backend `ctrl_backend_auth` to direct to one of three available Conductr Cores (`172.17.0.1`,`172.17.0.2` and `172.17.0.3`). In this case, each Control Server is listening on port `9055` as configured above.
+
+```
+frontend dummy
+  bind 127.0.0.1:65535
+
+frontend ctrl_frontend_secure
+  bind 0.0.0.0:9005 ssl crt /path/to/my/sslcert/ssl-conductr.cli.pem
+  mode http
+  acl ctrl_context path_beg /
+  use_backend ctrl_backend_auth if ctrl_context
+
+userlist ctrl_users
+  user steve insecure-password stevespassword
+
+backend ctrl_backend_auth
+  mode http
+  server ctrl_server_1 172.17.0.1:9055 maxconn 1024
+  server ctrl_server_2 172.17.0.2:9055 maxconn 1024
+  server ctrl_server_3 172.17.0.3:9055 maxconn 1024
+  acl ctrl_auth_ok http_auth(ctrl_users)
+  http-request auth realm ConductR if !ctrl_auth_ok
+```
+
+With the above setup, Control Protocol requests must be sent via HTTPS with Basic Authentication credentials. The ConductR CLI supports this via a credentials file that must be created at the following location `~/.conductr/settings.conf`, which must point to PEM file used to validate the SSL certificate locally (ss-conductr-cli.pem in the above example). Configuring this file is described in detail the ConductR CLI documentation section called [HTTP Basic Authentication](CLI#HTTP-Basic-Authentication).
+
 ### Enabling ConductR to reload HAProxy without altering the sudoers file
 
 On some systems, it may not be possible or desirable to provide root privileges to the conductr-agent such that it can execute the `/usr/bin/reloadHAProxy.sh` script. In these cases, it is still possible for ConductR to utilize HAProxy with a slightly modified configuration. Note that with this modified configuration, HAProxy will be limited to binding to ports greater than or equal to 1024. It will also limit the maximum number of connections (maxconn) to the maximum number of open file descriptors for non-root Linux users (1024 by default).


### PR DESCRIPTION
Cherry pick of https://github.com/typesafehub/conductr-doc/pull/327 for branch 2.0