### PR TITLE
Update sbt-conductr versioning (2.0)

### DIFF
--- a/src/main/play-doc/developer/DevQuickStart.md
+++ b/src/main/play-doc/developer/DevQuickStart.md
@@ -37,7 +37,13 @@ The conductr-cli is used to communicate with the ConductR cluster.
 To use `sbt-conductr` for your project add the plugin to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.2.4")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.3.0-RC1")
+```
+
+If your project is using Lagom 1.2.x or a previous version use:
+
+```scala
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.2.5")
 ```
 
 ## Signaling application state

--- a/src/main/play-doc/developer/SetupSbtConductr.md
+++ b/src/main/play-doc/developer/SetupSbtConductr.md
@@ -20,7 +20,13 @@ The conductr-cli is used to communicate with the ConductR cluster. The CLI also 
 Add sbt-conductr to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.2.4")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.3.0-RC1")
+```
+
+If your project is using Lagom 1.2.x or a previous version use:
+
+```scala
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.2.5")
 ```
 
 This makes several commands available within sbt. We'll use these commands on the next pages.


### PR DESCRIPTION
Use sbt-conductr 2.2.5 for Lagom 1.2.x or previous versions. Otherwise use sbt-conductr 2.3.0-RC1.