### PR TITLE
Tags related updates

### DIFF
--- a/src/main/play-doc/developer/BintrayPublishing.md
+++ b/src/main/play-doc/developer/BintrayPublishing.md
@@ -15,10 +15,10 @@ Bintray credentials are required to publish bundle and bundle configuration.
 Add [sbt-bintray-bundle](https://github.com/sbt/sbt-bintray-bundle) to the project.
 
 ```
-addSbtPlugin("com.typesafe.sbt" % "sbt-bintray-bundle" % "1.1.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-bintray-bundle" % "1.2.0")
 ```
 
-At the time of writing, the latest version of [sbt-bintray-bundle](https://github.com/sbt/sbt-bintray-bundle) is `1.1.1`. Replace this version with the latest version of the plugin.
+At the time of writing, the latest version of [sbt-bintray-bundle](https://github.com/sbt/sbt-bintray-bundle) is `1.2.0`. Replace this version with the latest version of the plugin.
 
 
 Configure the bintray credentials required for publishing.

--- a/src/main/play-doc/developer/BundleEnvironmentVariables.md
+++ b/src/main/play-doc/developer/BundleEnvironmentVariables.md
@@ -8,10 +8,11 @@ For reference, the following standard environment variables are available to a b
 Name                         | Description
 -----------------------------|------------
 BUNDLE_ID                    | The bundle identifier associated with the bundle and its optional configuration.
-BUNDLE_NAME				     | The name given to the bundle.
+BUNDLE_NAME				           | The name given to the bundle.
 BUNDLE_COMPATIBILITY_VERSION | A version to associate with the name.
 BUNDLE_SYSTEM                | A logical name that can be used to associate multiple bundles with each other. This could be an application or service association e.g. myapp.
 BUNDLE_SYSTEM_VERSION        | A version to associate with the system
+BUNDLE_TAGS                  | The bundle tags as a comma separated string, e.g. 1.0.0,backend
 BUNDLE_HOST_IP               | The IP address of a bundle component's host.
 CONDUCTR_CONTROL             | A URL for the control protocol of ConductR, composed as $CONDUCTR_CONTROL_PROTOCOL://$CONDUCTR_CONTROL_IP:$CONDUCTR_CONTROL_PORT
 CONDUCTR_CONTROL_PROTOCOL    | The protocol of the above.

--- a/src/main/play-doc/developer/CreatingBundles.md
+++ b/src/main/play-doc/developer/CreatingBundles.md
@@ -223,7 +223,7 @@ The [sbt-bintray-bundle](https://github.com/sbt/sbt-bintray-bundle) is used to p
 To add the Bintray bundle plugin to your `plugins.sbt`, or equivalent (check the [plugin's site](https://github.com/sbt/sbt-bintray-bundle) for the latest version):
 
 ```scala
-addSbtPlugin("com.typesafe.sbt" % "sbt-bintray-bundle" % "1.0.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-bintray-bundle" % "1.2.0")
 ```
 
 Once the plugin is added you need to declare some settings for your build. Here are some taken from [a sample Lagom based application](https://github.com/lagom/activator-lagom-java-chirper):

--- a/src/main/play-doc/operation/DeployingBundlesOps.md
+++ b/src/main/play-doc/operation/DeployingBundlesOps.md
@@ -27,8 +27,8 @@ conduct info --ip 172.17.0.1
 ...will yield something like:
 
 ```bash
-ID               NAME              #REP  #STR  #RUN
-23391d4-3cc322b  visualizer        3     0     0
+ID       NAME          TAG  #REP  #STR  #RUN  ROLES
+6cc7dbc  visualizer  2.0.0     3     0     0  web
 ```
 
 Run the Visualizer by executing:
@@ -39,9 +39,9 @@ conduct run --ip 172.17.0.1 visualizer
 
 Whenever you need to refer to a bundle you can use a prefix of or a full bundle id/name. Run `conduct info` once again, to see that the bundle has been successfully started.
 
-``` bash
-ID               NAME              #REP  #STR  #RUN
-23391d4-3cc322b  visualizer        3     0     1
+```bash
+ID       NAME          TAG  #REP  #STR  #RUN  ROLES
+6cc7dbc  visualizer  2.0.0     3     0     1  web
 ```
 
 > Pro tip: if you get bored of typing `--host` you can set the `CONDUCTR_HOST` environment variable instead.
@@ -86,8 +86,8 @@ The CLI comes with built-in URI and Bintray resolvers which comes into play when
 The URI resolver accepts local file system path as well as HTTP URL, e.g.
 
 ```
-conduct load /tmp/downloads/reactive-maps-frontend-v1-023f9da2243a0751c2e231b452aa3ed32fbc35351c543fbd536eea7ec457cfe2.zip
-conduct load http://192.168.0.1/files/reactive-maps-frontend-v1-023f9da2243a0751c2e231b452aa3ed32fbc35351c543fbd536eea7ec457cfe2.zip
+conduct load /tmp/downloads/reactive-maps-frontend-1.0.0-023f9da2243a0751c2e231b452aa3ed32fbc35351c543fbd536eea7ec457cfe2.zip
+conduct load http://192.168.0.1/files/reactive-maps-frontend-1.0.0-023f9da2243a0751c2e231b452aa3ed32fbc35351c543fbd536eea7ec457cfe2.zip
 ```
 
 ### Bintray resolver

--- a/src/main/play-doc/operation/Install.md
+++ b/src/main/play-doc/operation/Install.md
@@ -828,7 +828,7 @@ You can now use `dcos conduct <conduct-subcommand>` to connect with your DC/OS c
 
 ```
 $ dcos conduct info
-ID                 NAME                           #REP  #STR  #RUN
+ID  NAME  TAG  #REP  #STR  #RUN  ROLES
 ```
 
 ## Installing a Proxy on Ubuntu
@@ -1034,18 +1034,18 @@ Use the command `conduct info` from the bastion host to verify successful startu
 
 ```bash
 $ dcos conduct info
-ID       NAME        #REP  #STR  #RUN
-6e68f05  visualizer     1     0     1
+ID       NAME          TAG  #REP  #STR  #RUN  ROLES
+6e68f05  visualizer  2.0.0     3     0     1  web
 ```
 
 In the example above, a bundle called `visualizer` has been started successfully.
 
-This can also be confirmed by executing the `dcos task` command which will display the bundle running as a task from the context of DC/OS. The `visualizer-1` task belongs to the currently running `visualizer` bundle having `1` as the `compatibilityVersion`.
+This can also be confirmed by executing the `dcos task` command which will display the bundle running as a task from the context of DC/OS. The `visualizer:2.0.0` task belongs to the currently running `visualizer` bundle with the tag `2.0.0`.
 
 ```bash
 $ dcos task
-NAME           HOST       USER  STATE  ID
-visualizer-1   10.0.3.75  root    R    6e68f055d1f5715ad3ff19172fa5efaf_0f6e119c-9288-425a-89e3-36379dcaccda
+NAME              HOST       USER  STATE  ID
+visualizer:2.0.0  10.0.3.75  root    R    6e68f055d1f5715ad3ff19172fa5efaf_0f6e119c-9288-425a-89e3-36379dcaccda
 ```
 
 The `compatibilityVersion` is explained in the to [bundle configuration](BundleConfiguration).


### PR DESCRIPTION
- Update `sbt-bintray-bundle` to 1.2.0
- Update `conduct info` command to reflect the columns `TAG` and `ROLES`
- Update `dcos task` output given https://github.com/typesafehub/conductr/pull/1724
- Add `BUNDLE_TAGS` environment variable given https://github.com/typesafehub/conductr/pull/1723

Note that the bundle shorthand expression documentation doesn't need to be changed given the changes.