### PR TITLE
Installation: add command to allow HAProxy to bind to any port

### DIFF
--- a/src/main/play-doc/operation/Install.md
+++ b/src/main/play-doc/operation/Install.md
@@ -300,6 +300,12 @@ On RHEL and CentOS it may also be neccessary to [disable default requiretty](htt
 [172.17.0.1]$ echo 'Defaults: conductr-agent  !requiretty' | sudo tee -a /etc/sudoers
 ```
 
+Also if you have SELinux enabled on RHEL and CentOS, execute the following command to allow HAProxy to bind to any port.
+
+```bash
+[172.17.0.1]$ sudo setsebool haproxy_connect_any 1
+```
+
 HAProxy reload script is located in `/usr/bin/reloadHAProxy.sh` by default. ConductR-HAProxy will install its reload script in this location upon startup.
 
 We will limit the bundle's sudo privileges to running `/usr/bin/reloadHAProxy.sh`. Grant permissions to the `conductr-agent` user to run the `reloadHAProxy.sh` command. An addition to `/etc/sudoers` allows for using `sudo` without password for the `reloadHAProxy.sh` script.
@@ -650,6 +656,12 @@ On RHEL and CentOS it may also be neccessary to [disable default requiretty](htt
 [172.17.0.1]$ echo 'Defaults: conductr-agent  !requiretty' | sudo tee -a /etc/sudoers
 ```
 
+Also if you have SELinux enabled on RHEL and CentOS, execute the following command to allow HAProxy to bind to any port.
+
+```bash
+[172.17.0.1]$ sudo setsebool haproxy_connect_any 1
+```
+
 #### Optional dependencies
 
 ##### Docker
@@ -884,7 +896,13 @@ We will limit the bundle's sudo privileges to running `/usr/bin/reloadHAProxy.sh
 On RHEL and CentOS it may also be neccessary to [disable default requiretty](https://bugzilla.redhat.com/show_bug.cgi?id=1020147) for the named execution user in `sudoers`.
 
 ```bash
-$ echo 'Defaults: {executor-user}  !requiretty' | sudo tee -a /etc/sudoers
+[172.17.0.1]$ echo 'Defaults: {executor-user}  !requiretty' | sudo tee -a /etc/sudoers
+```
+
+Also if you have SELinux enabled on RHEL and CentOS, execute the following command to allow HAProxy to bind to any port.
+
+```bash
+[172.17.0.1]$ sudo setsebool haproxy_connect_any 1
 ```
 
 Skip the next section and scroll down to ["Loading and Running ConductR-HAProxy Bundle"](#Loading_and_Running_ConductR-HAProxy_Bundle).


### PR DESCRIPTION
This is only required for RHEL and CentOS when SELinux is enabled.