### PR TITLE
ConductrAgent class renaming

### DIFF
--- a/src/main/play-doc/operation/ClusterTroubleshooting.md
+++ b/src/main/play-doc/operation/ClusterTroubleshooting.md
@@ -50,7 +50,7 @@ http://dcos-host/mesos >> Find the executor with a task name "conductr-agent-boo
 * Find the pid of the ConductR executor:
 
 ```bash
-ps aux | grep [c]onductr.agent.ConductRAgent | awk '{print $2}'
+ps aux | grep [c]onductr.agent.ConductrAgent | awk '{print $2}'
 ```
 
 * Terminate the executor on the host by using the retrieved pid:


### PR DESCRIPTION
The PR https://github.com/typesafehub/conductr/pull/1701 renaming the class `ConductRAgent` to `ConductrAgent`. This PR is updating the documentation accordingly.

This change doesn't need to be backported to ConductR 2.0.x because the class renaming was also not backported to previous versions.