### PR TITLE
Enhance documentation to better cover OCI and bndl

### DIFF
--- a/src/main/play-doc/api/ControlAPI.md
+++ b/src/main/play-doc/api/ControlAPI.md
@@ -275,7 +275,7 @@ Field               | Description
 address             | The location of a ConductR member.
 annotations         | An optional HOCON string representing additional metadata that you may wish to associate with a bundle. Key names should be in accordance with the OCI image annotation conventions. Annotations relate to metadata that should be associated with a bundle, but is of no direct concern to ConductR itself. Note that while you may upload many annotations, only those annotations that are declared by ConductR core's `conductr.control-server.core-annotation-paths` will be included here (which, by default, is just `com.lightbend.conductr.application-ids`)
 affinity            | The bundle identifier that references a different bundle. If specified, the current bundle will be run on the same host where the specified bundle is currently running.
-bindPort            | The network port that is used by a bundle component to bind to an interface. This may be the same value as the `hostPort` when running outside of a container.
+bindPort            | The network port that is used by a bundle component to bind to an interface. This may be the same value as the `hostPort` when running outside of Docker.
 bindProtocol        | The network protocol that is used by a bundle component to bind to an interface.
 bundleDigest        | The hex form of a digest representing the contents of the bundle.
 bundleFile          | The location of a bundle archive on disk.

--- a/src/main/play-doc/developer/BundleConfiguration.md
+++ b/src/main/play-doc/developer/BundleConfiguration.md
@@ -51,15 +51,15 @@ The following table describes each property:
 Name                 | Description
 ---------------------|-------------
 acls     			 | Discussed [below](#Endpoints).
-annotations           | A [HOCON](https://github.com/typesafehub/config/blob/master/HOCON.md) value describing any additional metadata that ConductR itself is not concerned with. Annotation keys should be namespaced as per the [OCI image specification](https://github.com/opencontainers/image-spec/blob/master/annotations.md).
+annotations          | A [HOCON](https://github.com/typesafehub/config/blob/master/HOCON.md) value describing any additional metadata that ConductR itself is not concerned with. Annotation keys should be namespaced as per the [OCI image specification](https://github.com/opencontainers/image-spec/blob/master/annotations.md).
 bind-port			 | Discussed [below](#Endpoints).
-compatibility-version | A versioning scheme that will be associated with a bundle that describes the level of compatibility with the bundle that went before it. ConductR can use this property to reason about the compatibility of one bundle to another given the same bundle name. By default we take the major version component of a version as defined by <http://semver.org/>. However you can make this mean anything that you need it to mean in relation to the bundle produced prior to it. We take the notion of a compatibility version from <http://ometer.com/parallel.html>.
+compatibility-version| A versioning scheme that will be associated with a bundle that describes the level of compatibility with the bundle that went before it. ConductR can use this property to reason about the compatibility of one bundle to another given the same bundle name. By default we take the major version component of a version as defined by <http://semver.org/>. However you can make this mean anything that you need it to mean in relation to the bundle produced prior to it. We take the notion of a compatibility version from <http://ometer.com/parallel.html>.
 components			 | Each bundle has at least one component, and generally just one. A bundle component contains all that is required to run itself in terms of its directory on disk when the bundle is expanded. This section describes the meta data required for each bundle component.
 description			 | A human readable description of the bundle component.
 disk-space           | The amount of disk space required to host an expanded bundle and configuration.
 endpoints            | Discussed [below](#Endpoints).
-file-system-type	 | Describes the type of the bundle and can be either "universal" or "docker". A universal type means that this bundle copmonent will be run outside of a container. The Host environment will therefore be available, including a Java runtime. Docker types expect a Dockerfile to reside within a component. The Docker component will be built and run at the time of the bundle being run.
-memory               | The amount of resident memory required to run the bundle. Use the Unix top command to determine this value by observing the RES and rounding up to the nearest 10MiB.
+file-system-type	 | Discussed [below](#File-System-Types).
+memory               | The amount of resident memory required to run the bundle. Use the UNIX `top` command to determine this value by observing the RES and rounding up to the nearest 10MiB.
 name				 | The human readable name of the bundle. This name appears often in operational output such as the CLI.
 nr-of-cpus           | The minimum number of cpus required to run the bundle (can be fractions thereby expressing a portion of CPU). This value is considered when starting a bundle on a node. If the specified CPUs exceeds the available CPUs on a node, then this node is not considered for scaling the bundle. Once running, the application is not restricted to the given value and tries to use all available CPUs on the node. Required.
 protocol			 | Discussed [below](#Endpoints).
@@ -86,20 +86,31 @@ The following port definitions are used:
 Name         | Description
 -------------|------------
 service-port | The port number to be used as the public-facing port. It is proxied to the host-port.
-host-port    | This is not declared but is dynamically allocated if bundle is running in a container. Otherwise it has the same value as bind-port.
+host-port    | This is not declared but is dynamically allocated if bundle is running in a docker container. Otherwise it has the same value as bind-port.
 bind-port    | The port the bundle component's application or service actually binds to. When this is 0 it will be dynamically allocated (which is the default).
 
 Endpoints are declared using an `endpoint` setting using a Map of `endpoint-name` -> `Endpoint(bindProtocol, bindPort, serviceName, acls)` pairs.
 
 The bind-port allocated to your bundle will be available as an environment variable to your component. For example, given the default settings where an endpoint named "web" is declared that has a dynamically allocated port, an environment variable named `WEB_BIND_PORT` will become available. `WEB_BIND_IP` is also available and should be used as the interface to bind to.  
 
-Service names are declared through `serviceName` property for each endpoint. A service name is used address the service when performing a service lookup. [[Resolving services|ResolvingServices]] describes service resolution in a greater detail.
+Service names are declared through `service-name` property for each endpoint. A service name is used to address the service when performing a service lookup. [[Resolving services|ResolvingServices]] describes service resolution in a greater detail.
 
 The request acls is declared through the `acls` property, and allows declaration of HTTP, TCP, and UDP based endpoints. [[ACL configuration|AclConfiguration]] describes how to configure request acls in a greater detail.
 
+### File System Types
+
+A component must declare its `file-system-type`. See the table below for a reference of available types and their behavior.
+
+Type        | Description
+------------|------------
+universal   | The bundle component will be run outside of a container. The Host environment will therefore be available, including a Java runtime.
+oci-image   | The bundle component contains a valid OCI image specification. These can be created from Docker images and contain everything needed to run your component without the need to resolve or build images at runtime. It will be run inside a container by `runc` for process isolation but will share and retain access to the host network. When running `oci-image` components in the Developer Sandbox, they are executed inside Docker containers to ensure a consistent development experience across operating systems.
+oci-bundle  | The bundle component contains a valid OCI runtime specification. It will be run inside a container by `runc` for process isolation but will share and retain access to the host network. When running `oci-bundle` components in the Developer Sandbox, they are executed inside Docker containers to ensure a consistent development experience across operating systems.
+docker      | The bundle component must contain a `Dockerfile` that will be built and run at the time of the bundle being run.
+
 ### Docker Containers and ports
 
-When your component will run within a container you may alternatively declare the bind port to be whatever it may be. Taking our Play example again, we can set the bind port with no problem of it clashing with another port given that it is run within a container:
+When your component will run within a Docker container you may alternatively declare the bind port to be whatever it may be. Taking our Play example again, we can set the bind port with no problem of it clashing with another port given that it is run within a container:
 
 ```json
     endpoints        = {
@@ -129,9 +140,7 @@ When your component will run within a container you may alternatively declare th
 
 It is sometimes not possible or practical to change source code in order to signal successful startup or have it use the environment variables that ConductR provides.
 
-We provide a [CLI](https://github.com/typesafehub/typesafe-conductr-cli#command-line-interface-cli-for-typesafe-conductr) command named [`shazar`](https://github.com/typesafehub/typesafe-conductr-cli#shazar) for bundling the contents of any folder. You can therefore hand-craft a `bundle.conf` and its component folders and use `shazar` to bundle it.
-
-As a quick example, suppose that you wish to bundle [ActiveMQ](http://activemq.apache.org/) as a Docker component with a `Dockerfile`. You can do something like this (btw: we appreciate that you cannot change the world in one go and don't always have the luxury of using Akka for messaging!):
+As a quick example, suppose that you wish to bundle [ActiveMQ](http://activemq.apache.org/) as a Docker component with a `Dockerfile`. Suppose you have a bundle saved in `my-active-mq.zip` with a  `bundle.conf` defined as follows:
 
 ```
 version               = "1"
@@ -166,44 +175,46 @@ components = {
       }
     }
   }
-  "jms-status" = {
-    description      = "Status check for the jms component"
-    file-system-type = "universal"
-    start-command    = ["check", "docker+$JMS_HOST"]
-    endpoints        = {}
-  }
 }
 ```
 
-The declaration of interest is the `jms-status` component. ConductR provides a `check` command that bundle components may use to poll a tcp endpoint until it becomes available. `docker` instructs `check` to wait for all Docker components of this bundle to start and `JMS_HOST` is a [standard environment variable](https://github.com/sbt/sbt-bundle#standard-environment-variables) that will be provided at runtime given the `"jms"` endpoint declaration; it is a URI describing the JMS endpoint. You can similarly poll http endpoints and wait for them to become available. Note in this examples that the check parameter `docker+$JMS_HOST` is specific to the endpoint `jms.` An endpoint of `webserver` would use `docker+$WEBSERVER_HOST` instead.
+ConductR provides a `check` command that bundle components may use to poll a tcp endpoint until it becomes available. The following example will add a `check` component that will correctly signal ConductR when your bundle has started.
 
-#### To Docker or Not
+```bash
+conduct load my-active-mq.zip --check 'docker+$JMS_HOST'
+```
 
-[Docker](https://www.docker.com/) is a technology that provides containers for your application or service. Most Lightbend Reactive Platform (Lightbend RP) based programs should not require Docker as the host OS's Java Runtime Environment 8 (JRE 8) environment should be sufficient. Bundles generally contain all that is required for a Lightbend RP program to run, with exception to the Host OS and the host JRE. Lightbend RP, and being JVM based in general, bundles will start faster and incur less system resources when used without Docker.
+`docker` instructs `check` to wait for all Docker components of this bundle to start and `JMS_HOST` is a [standard environment variable](https://github.com/sbt/sbt-bundle#standard-environment-variables) that will be provided at runtime given the `"jms"` endpoint declaration; it is a URI describing the JMS endpoint. You can similarly poll http endpoints and wait for them to become available. Note in this examples that the check parameter `docker+$JMS_HOST` is specific to the endpoint `jms.` An endpoint of `webserver` would use `docker+$WEBSERVER_HOST` instead.
 
-Docker becomes relevant when there are specific runtime dependencies that are different to ConductR's host OS environment. In particular if a binary program that does not use the JVM is required to be launched from a bundle then it becomes more likely to benefit from using a Docker container.
+#### To Containerize or Not
 
-> For more Docker bundle options see "[Creating Bundles](Creating Bundles)".
+The [Open Container Initiative](https://www.opencontainers.org/) established an open standard for container formats and runtimes. Containers can be leveraged to provide process isolation and security gains as well as runtime dependency packaging.
+
+Most Lightbend Reactive Platform (Lightbend RP) based programs should not require to be containerized as the host OS's Java Runtime Environment 8 (JRE 8) environment should be sufficient. Bundles generally contain all that is required for a Lightbend RP program to run, with exception to the Host OS and the host JRE. Lightbend RP, and being JVM based in general, bundles will start faster and incur less system resources when used without Docker.
+
+Containers becomes relevant when there are specific runtime dependencies that are different to ConductR's host OS environment or when you wish to leverage the enhanced security capabilities provided by containers. In particular if a binary program that does not use the JVM is required to be launched from a bundle then it becomes more likely to benefit from using a container.
+
+> For more container bundle options including OCI and Docker, see "[Creating Bundles](Creating Bundles)".
 
 ## Configuration Bundles
 
 Configuration bundles are bundles containing only configuration values such as API keys and secrets. Configuration bundles are deployed together with application bundles. This keeps the configuration out of the application code and enables application bundles to be deployed to various environments without repackaging the application bundle.
 
-To create a configuration bundle, run [`shazar`](https://github.com/typesafehub/typesafe-conductr-cli#shazar) on a directory containing a `runtime-config.sh` and/or `bundle.conf` file. The `runtime-config.sh` file should export any environment variables to be set. The `bundle.conf` file should contain any bundle key settings to be overridden. Only the values to be overridden need to be specified. Bundle key values already defined the application bundle do not need to be redefined.
+To create a configuration bundle, run [`bndl`](https://github.com/typesafehub/conductr-cli/blob/master/README.rst#bndl) on a directory containing a `runtime-config.sh` and/or `bundle.conf` file. The `runtime-config.sh` file should export any environment variables to be set. The `bundle.conf` file should contain any bundle key settings to be overridden. Only the values to be overridden need to be specified. Bundle key values already defined the application bundle do not need to be redefined.
 
-For example to set an application secret and override the application's declared role, simply create the configuration files into a directory and shazar the directory containing the files. The configuration bundle will take its name from the directory name.
+For example to set an application secret and override the application's declared role, simply create the configuration files into a directory and run `bndl` on the directory containing the files. You'll also need to provide a name for your bundle configuration file.
 
 ```bash
 mkdir test-config
 echo 'export "APPLICATION_SECRET=thisismyapplicationsecret-pleasedonttellanyone"'> test-config/runtime-config.sh
 echo 'roles      = [partner-frontend]' > test-config/bundle.conf
-shazar test-config
+bndl -f configuration -o test-config.zip test-config
 ```
 
-The resultant bundle, i.e. `test-config-2ddf3c2453ad16589b7bfae316e6ec746418491292f874b72236741bbd8f84ab.zip` is then loaded together with the application.
+The resultant bundle, i.e. `test-config.zip` is then loaded together with the application.
 
 ```bash
-conduct load webserver-015f73613aa48d397b0dbab6d7f96d687c56d72a275a5ea43d7da44a21c27482.zip test-config-2ddf3c2453ad16589b7bfae316e6ec746418491292f874b72236741bbd8f84ab.zip
+conduct load webserver-015f73613aa48d397b0dbab6d7f96d687c56d72a275a5ea43d7da44a21c27482.zip test-config.zip
 ```
 
 Where `webserver-015f73613aa48d397b0dbab6d7f96d687c56d72a275a5ea43d7da44a21c27482.zip` is the application bundle.
@@ -213,8 +224,6 @@ Alternatively, you can also provide the configuration directory directly to `con
 ```bash
 conduct load webserver-015f73613aa48d397b0dbab6d7f96d687c56d72a275a5ea43d7da44a21c27482.zip test-config
 ```
-
-
 
 ### Configuration Bundle Files
 
@@ -237,4 +246,16 @@ TARGET="my-component/conf"
 
 ...where `my-component/conf` is the configuration folder of the associated bundle with a component named `my-component`.
 
-> `runtime-config.sh` is the name preferred by ConductR when searching for a script to execute within a configuration bundle. However you can name the configuration script anything that you like. In the case of ambiguity though, for example where you have `a.sh` and `b.sh`, ConductR does not know which is the one to select, and it can select either depending on your JDK. In most cases then, you're better to stick with `runtime-config.sh`
+### Dynamic Configuration Bundles
+
+ConductR's CLI includes the ability to automatically generate a configuration bundle for you based on provided arguments. This allows you to specify `bundle.conf` parameters and environment variable values without explicitly creating any files. For example, the following loads a bundle and specifies roles and environment variables from the command line:
+
+```bash
+conduct load webserver-015f73613aa48d397b0dbab6d7f96d687c56d72a275a5ea43d7da44a21c27482.zip \
+    --env APPLICATION_SECRET=thisismyapplicationsecret-pleasedonttellanyone \
+    --roles partner-frontend
+```
+
+If you use these arguments in conjunction with an explicit configuration bundle, they will be merged into your `bundle.conf` and `runtime-config.sh`.
+
+For a complete listing of arguments, be sure to consult `conduct load -h`.

--- a/src/main/play-doc/developer/CreatingBundles.md
+++ b/src/main/play-doc/developer/CreatingBundles.md
@@ -127,7 +127,7 @@ The `javaOptions` values declare the maximum and minimum heap size for your appl
 `BundleKeys.memory` is used for locating machines with enough resources to run your application, and so it is particularly important to size it before you go to production.
 
 ## Producing an OCI bundle with Docker
-ConductR is capable of running images that have been exported from Docker. To do this, you can use the `bndl` tool to convert a Docker image into a ConductR bundle. Behind the scenes, we're using the standard OCI Image format so you can be sure your images are free of vendor lock-in. Additionally, this approach doesn't require Docker to be installed in production; ConductR provides everything necessary to run these images.
+ConductR is capable of running images that have been exported from Docker. To do this, you can use the `bndl` tool to convert a Docker image into a ConductR bundle that employs the OCI Image format. Since this is an open standard, it helps manage vendor lock-in. Additionally, this approach doesn't require Docker to be installed in production; ConductR provides everything necessary to run these images.
 
 The following command will fetch the image `dockercloud/hello-world` with tag `stdout` from DockerHub and load it directly into ConductR. If the tag is omitted, `latest` is used.
 

--- a/src/main/play-doc/developer/CreatingBundles.md
+++ b/src/main/play-doc/developer/CreatingBundles.md
@@ -3,52 +3,24 @@
 Once the application is ready for deployment, developers can view ConductR bundles as just yet another deployment target. We offer a few methods of building a bundle:
 
 1. Using an [sbt](http://www.scala-sbt.org/) plugin with your build
-2. Using `bndl` to create bundles from Docker images
-2. Using `shazar` (we invented that name!)
+2. Using `bndl` to create bundles from Docker images, OCI images, or application directories
 
 If you can make changes to the application or service then `sbt-conductr` is what you will typically use to produce a bundle. In fact you can even use sbt-conductr to produce bundles for other applications or services. However you may find yourself crafting a bundle from scratch and for the latter scenario. See the "legacy & third party bundles" section of the [bundles](BundleConfiguration#Legacy-&-third-party-bundles) document for more information on that, and for a deep dive on bundles in general. For now, let's look at bundling a project that you have control of.
 
 ConductR supports several different types of bundle components.
-  * OCI bundle components (introduced in 2.1) package an entire container in the bundle. They can be produced from Docker images. They run inside a container using `runc`.
+  * OCI bundle components (introduced in 2.1) package an entire container filesystem in the bundle. They can be produced from Docker images and run inside a container using `runc` but share access to the host's network.
   * Universal bundle components run directly on the host.
   * Docker bundle components build a provided `Dockerfile` and run the resulting image
   
 In addition, Docker images can be run from "universal" bundles. The following sections cover each of these scenarios:
 
-* [Producing an OCI bundle with Docker](#producing-an-oci-bundle-with-docker)
 * [Producing a universal bundle without Docker](#producing-a-universal-bundle-without-docker)
+* [Producing an OCI bundle with Docker](#producing-an-oci-bundle-with-docker)
 * [Producing a universal bundle that runs a Docker image](#producing-a-universal-bundle-that-runs-a-docker-image)
 * [Producing a docker bundle that uses a Dockerfile](#producing-a-docker-bundle-that-uses-a-dockerfile)
+* [Producing modified bundles with `bndl`](#producing-modified-bundles-with-`bndl`)
 
-## Producing an OCI bundle with Docker
-ConductR is capable of running images that have been exported from Docker. To do this, you use the `bndl` tool to convert a docker image into a ConductR bundle. Behind the scenes, we're using the standard OCI Image format so you can be sure your images are free of vendor lock-in. Additionally, this approach doesn't require Docker to be installed in production; ConductR provides everything necessary to run these images.
-
-The following command will fetch the image `dockercloud/hello-world` with tag `stdout` from DockerHub and load it directly into ConductR. If the tag is omitted, `latest` is used.
-
-```bash
-conduct load dockercloud/hello-world:stdout
-```
-
-Private registries are also supported using traditional notation.
-
-```bash
-conduct load some-registry.bintray.io/some-project/some-image:some-tag
-```
-
-
-
-If you'd rather save the resulting bundle to a file, you can do this using `docker save` and `bndl -o <filename>`.
-```bash
-docker pull dockercloud/hello-world:stdout
-docker save dockercloud/hello-world:stdout | bndl -o dockercloud-hello-world.zip
-```
-
-
-We attempt to extract as much information from the your docker image as possible. Any `EXPOSE` directives in your `Dockerfile` will automatically create corresponding service endpoints in `bundle.conf`. Support for persistent mounting of `VOLUME` directives is planned.
-
-Docker images can vary in size significantly and this can affect development/deployment time and consume additional system resources. Because of this, we recommend that you build your images ontop of a light-weight base image. [openjdk/8-jre-alpine](https://hub.docker.com/_/openjdk/) is a great choice as it's only ~80MB in size (~50MB when compressed). 
-
-## Producing a universal bundle without Docker
+## Producing a universal bundle
 
 With [sbt-conductr](https://github.com/typesafehub/sbt-conductr) you can produce a ConductR bundle for your application. sbt-conductr extends the [sbt-native-packager](https://github.com/sbt/sbt-native-packager#sbt-native-packager). Just as developers might use `sbt dist` or `sbt debian:packageBin` to produce production binaries of an application, the sbt `bundle:dist` task from sbt-conductr is used to produce ConductR application bundles.
 
@@ -154,9 +126,36 @@ The `javaOptions` values declare the maximum and minimum heap size for your appl
 
 `BundleKeys.memory` is used for locating machines with enough resources to run your application, and so it is particularly important to size it before you go to production.
 
+## Producing an OCI bundle with Docker
+ConductR is capable of running images that have been exported from Docker. To do this, you can use the `bndl` tool to convert a Docker image into a ConductR bundle. Behind the scenes, we're using the standard OCI Image format so you can be sure your images are free of vendor lock-in. Additionally, this approach doesn't require Docker to be installed in production; ConductR provides everything necessary to run these images.
+
+The following command will fetch the image `dockercloud/hello-world` with tag `stdout` from DockerHub and load it directly into ConductR. If the tag is omitted, `latest` is used.
+
+```bash
+conduct load dockercloud/hello-world:stdout
+```
+
+Private registries are also supported using traditional notation.
+
+```bash
+conduct load some-registry.bintray.io/some-project/some-image:some-tag
+```
+
+If you'd rather save the resulting bundle to a file, you can do this using `docker save` and `bndl -o <filename>`.
+```bash
+docker pull dockercloud/hello-world:stdout
+docker save dockercloud/hello-world:stdout | bndl -o dockercloud-hello-world.zip
+```
+
+We attempt to extract as much information from the your docker image as possible. Any `EXPOSE` directives in your `Dockerfile` will automatically create corresponding service endpoints in `bundle.conf`. Any `VOLUME` directives will result in a host directory being mounted into the container at the declared path. If the defaults are not appropriate, they can be overridden using the `--volume` and `--endpoint` arguments.
+
+Volumes are stored in `$HOME/.conductr/volumes` and are namespaced by `bundle.conf` properties `name` and `compatibility-version`. These volumes are therefore persistent across cluster restarts.
+
+Docker images can vary in size significantly and this can affect development/deployment time and consume additional system resources. Because of this, we recommend that you build your images ontop of a light-weight base image. [openjdk/8-jre-alpine](https://hub.docker.com/_/openjdk/) is a great choice as it's only ~80MB in size (~50MB when compressed). 
+
 ## Producing a universal bundle that runs a Docker image
 
-If you'd prefer, or indeed require to run a Docker image directly then you can set up one via sbt. Here is a section of `conductr-kibana`'s build file:
+If you'd prefer, or indeed require to run a Docker image using `docker run` then you can set up one via sbt. Here is a section of `conductr-kibana`'s build file:
 
 ```scala
 import ByteConversions._
@@ -236,7 +235,12 @@ BundleKeys.startCommand := Seq.empty
 BundleKeys.checks := Seq(uri("docker+$POSTGRES_HOST"))
 ```
 
-> When deploying Docker bundles to the sandbox they won't work. The sandbox is using Docker itself and you cannot run Docker within Docker. For development purposes setup a single VM and configure it as per the regular Linux installation along with Docker. You'll then be able to test your Docker bundles locally.
+## Producing modified bundles with `bndl`
+If you already have a bundle, the CLI ships with a `bndl` command that can be used to modify its `bundle.conf` and `runtime-config.sh` files. Below is an example that updates the memory and CPU requirements for a bundle (`my-bundle.zip`) and produces a new bundle (`my-updated-bundle.zip`). Consult `bndl -h` for a list of other options.
+
+```bash
+bndl my-bundle.zip -o my-updated-bundle.zip --nr-of-cpus 2 --memory 2147483648 
+```
 
 ## Publishing bundles
 

--- a/src/main/play-doc/operation/CLI.md
+++ b/src/main/play-doc/operation/CLI.md
@@ -32,6 +32,10 @@ commands:
 ...
 ```
 
+## DC/OS
+
+The CLI is able to integrate with the DC/OS CLI e.g. `dcos conduct info` will render the current ConductR state on DC/OS. To setup CLI integration type `conduct setup-dcos`.
+
 ## Packaging configuration
 
 In addition to consuming services provided by ConductR, the CLI also provides a quick way of packaging custom configuration to a bundle. We will go through most of the CLI features by deploying the Visualizer bundle to ConductR that comes together with the ConductR installation. The Visualizer can be resolved and loaded from the [bundles repo](https://bintray.com/typesafe/bundle) using the `load` command.
@@ -48,18 +52,15 @@ Some applications require additional configuration when deployed to different en
 
 A strong feature of ConductR is that configuration may be coupled with a bundle at the time of loading. Thus a bundle can be associated with different configurations; perhaps one configuration for a test environment, and another for production. Furthermore, different versions of a bundle may be associated with the same configuration. Whatever the combination is, the bundle and its configuration that is loaded may always be distinguished from others given that unique identifiers are returned for them.
 
-Configuration files are executed just before a bundle starts. Let's create a configuration file that exports a `POLL_INTERVAL` environment variable containing a shorter than default poll interval (which is 100ms):
+Let's load the visualizer but specify the `POLL_INTERVAL` environment variable.
 
 ```bash
-cd #back to your home folder so we know where we're playing
-echo "export POLL_INTERVAL=500ms" >> ./visualizer-poll-interval.sh
+conduct load visualizer --env POLL_INTERVAL=500ms
 ```
 
-Once the configuration file is ready, we can load it directly into ConductR. The configuration is always provided as the second parameter to the `conduct load` command.
+This created a *configuration bundle* for you that contains a `runtime-config.sh` file and loaded it alongside the visualizer. This file will be executed by ConductR immediately before it starts your bundle.
 
-```bash
-conduct load visualizer ./visualizer-poll-interval.sh
-```
+> You could also create a `runtime-config.sh` yourself if you needed to implement more advanced logic. For more information on this and other configuration options, see "[Bundle Configuration](../developer/BundleConfiguration)".
 
 ## Accessing the Visualizer
 
@@ -74,10 +75,6 @@ conduct run --host 172.17.0.1 --scale 2 visualizer
 You should see another green circle start spinning, which means that another instance of Visualizer was started. Play around with more `conduct` commands and see how it affects ConductR cluster visualization.
 
 Our aim is to make using Lightbend ConductR by operators akin to using Play by developers; a joyful and productive experience! ConductR starts to shine when used in the context of managing more than 2 nodes; a common scenario for reactive applications. Go and spin those nodes up!
-
-## DC/OS
-
-The CLI is able to integrate with the DC/OS CLI e.g. `dcos conduct info` will render the current ConductR state on DC/OS. To setup CLI integration type `conduct setup-dcos`.
 
 ## HTTP Basic Authentication
 

--- a/src/main/play-doc/operation/DeployingBundlesOps.md
+++ b/src/main/play-doc/operation/DeployingBundlesOps.md
@@ -79,7 +79,7 @@ In the example above the bundle shorthand expression `reactive-maps-backend-regi
 
 ## Built-in bundle resolvers
 
-The CLI comes with built-in URI and Bintray resolvers which comes into play when `conduct load` command is invoked.
+The CLI comes with a number of built-in resolvers that come into play when `conduct load` command is invoked.
 
 ### URI resolver
 

--- a/src/main/play-doc/operation/DynamicProxyConfiguration.md
+++ b/src/main/play-doc/operation/DynamicProxyConfiguration.md
@@ -200,13 +200,11 @@ The custom reload script in the example above issued the `/usr/local/bin/haproxy
 
 Use the CLI to package the configuration override:
 
-```lang-none
-shazar /tmp/custom-haproxy-conf
-Created digested ZIP archive at ./custom-haproxy-conf-ffd0dcf76f4d565424a873022fbb39f3025d4239c87d307be3078b320988b052.zip
-
+```bash
+bndl -f configuration /tmp/custom-haproxy-conf -o custom-haproxy-conf.zip
 ```
 
-The generated file `custom-haproxy-conf-ffd0dcf76f4d565424a873022fbb39f3025d4239c87d307be3078b320988b052.zip` is the configuration override that can be loaded alongside ConductR HAProxy bundle.
+The generated file `custom-haproxy-conf.zip` is the configuration override that can be loaded alongside ConductR HAProxy bundle.
 
 
 ### Load the custom HAProxy configuration template
@@ -215,7 +213,7 @@ _If there's an existing ConductR HAProxy running within ConductR, the running Co
 
 Once custom configuration override is generated, it can be loaded into ConductR, e.g:
 
-```lang-none
+```bash
 conduct load /tmp/conductr-haproxy-v2-0d24d10cb0d1af9bf9f7e0bf81778a61d2cc001f9393ef035cb343722da3ac87.zip /tmp/custom-haproxy-conf-ffd0dcf76f4d565424a873022fbb39f3025d4239c87d307be3078b320988b052.zip
 ```
 
@@ -436,13 +434,11 @@ These HTTP ports by will be exposed to the HAProxy docker container when the San
 
 Use the CLI to package the configuration override:
 
-```lang-none
-shazar /tmp/custom-haproxy-conf
-Created digested ZIP archive at ./custom-haproxy-conf-ffd0dcf76f4d565424a873022fbb39f3025d4239c87d307be3078b320988b052.zip
-
+```bash
+bndl -f configuration -o custom-haproxy-conf.zip /tmp/custom-haproxy-conf
 ```
 
-The generated file `custom-haproxy-conf-ffd0dcf76f4d565424a873022fbb39f3025d4239c87d307be3078b320988b052.zip` is the configuration override that can be loaded alongside ConductR HAProxy bundle.
+The generated file `custom-haproxy-conf.zip` is the configuration override that can be loaded alongside ConductR HAProxy bundle.
 
 
 ### Load the custom HAProxy configuration template
@@ -451,8 +447,8 @@ _If there's an existing ConductR HAProxy running within ConductR, the running Co
 
 Once custom configuration override is generated, it can be loaded into ConductR, e.g:
 
-```lang-none
-conduct load /tmp/conductr-haproxy-v2-0d24d10cb0d1af9bf9f7e0bf81778a61d2cc001f9393ef035cb343722da3ac87.zip /tmp/custom-haproxy-conf-ffd0dcf76f4d565424a873022fbb39f3025d4239c87d307be3078b320988b052.zip
+```bash
+conduct load /tmp/conductr-haproxy-v2-0d24d10cb0d1af9bf9f7e0bf81778a61d2cc001f9393ef035cb343722da3ac87.zip custom-haproxy-conf.zip
 ```
 
 In the example above, the files required are placed within the `/tmp` directory. Replace the `/tmp` with the actual path to the files.
@@ -993,7 +989,17 @@ echo -Dconductr-haproxy.configurator.command.0="/bin/bash" | tee -a "${CONFIG_FI
 echo -Dconductr-haproxy.configurator.command.1="$CONFIG_DIR/reload-haproxy-nosudo.sh" | tee -a "${CONFIG_FILE}"
 ```
 
-Finally, you will need to use `shazar` to package the custom configuration bundle before loading it to ConductR as described above.
+Finally, you can use the following command to load `conductr-haproxy` with a custom configuration:
+
+```bash
+conduct load conductr-haproxy /tmp/custom-haproxy-conf
+```
+ 
+Should you wish to save the configuration bundle for use later, the following command will create a bundle file for you instead:
+
+```bash
+bndl /tmp/custom-haproxy-conf -f configuration -o ~/my-conductr-haproxy-config.zip
+```
 
 ## Troubleshooting
 

--- a/src/main/play-doc/operation/ThirdPartyServices.md
+++ b/src/main/play-doc/operation/ThirdPartyServices.md
@@ -1,0 +1,91 @@
+# Third-Party Services
+
+ConductR's method of delivering third-party service support embraces the [Open Container Initiative](https://www.opencontainers.org/) specifications. A vendor simply needs to provide a Docker or OCI image and ConductR can then take care of deploying and scaling it across your cluster.
+
+We've spent a lot of effort ensuring that essential services will work correctly in a ConductR cluster. Below, you'll find a curated list of common applications and the required arguments to load them into your cluster.
+
+* [Elasticsearch](#Elasticsearch)
+* [Kafka](#Kafka)
+* [MySQL](#MySQL)
+* [PostgreSQL](#PostgreSQL)
+* [ZooKeeper](#ZooKeeper)
+
+#### Elasticsearch
+
+[Elasticsearch](https://www.elastic.co/products/elasticsearch) is a search and analytics engine. The example below deploys [elastic](https://www.elastic.co/)'s image into your ConductR cluster. For more information on this image and its arguments, refer to [Install Elasticsearch with Docker](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html).
+
+
+```bash
+conduct load docker.elastic.co/elasticsearch/elasticsearch:5.4.0 \
+    --start-command '[
+        "bin/elasticsearch", 
+        "-Enetwork.bind_host=$ELASTICSEARCH_TCP_9200_BIND_IP", 
+        "-Ehttp.port=$ELASTICSEARCH_TCP_9200_BIND_PORT", 
+        "-Enetwork.publish_host=$BUNDLE_HOST_IP", 
+        "-Expack.security.enabled=false", 
+        "-Ecluster.name=conductr"
+    ]' \
+    --volume es-data=/usr/share/elasticsearch/data \
+    --endpoint elasticsearch-tcp-9200 \
+        --service-name elastic-search \
+        --bind-port 0 \
+        --bind-protocol http
+```
+
+#### Kafka
+
+[Kafka](https://kafka.apache.org/) is a distributed streaming platform that can be used to publish, subscribe, and process streams of data in real-time. The example below deploys [Confluent, Inc](https://www.confluent.io/)'s Kafka image into your ConductR cluster. For more information on this image and its arguments, refer to [Confluent's Documentation](http://docs.confluent.io/current/cp-docker-images/docs/configuration.html#confluent-kafka-cp-kafka).
+
+*Please note that Kafka relies on [ZooKeeper](#ZooKeeper) for coordination. Ensure that it is available in your ConductR cluster via the service name `zookeeper`.*  
+
+```bash
+conduct load confluentinc/cp-kafka \
+    --endpoint cp-kafka-tcp-9092 \
+        --service-name kafka \
+        --bind-port 0 \
+    --volume kafka-data=/var/lib/kafka/data \
+    --volume kafka-secrets=/etc/kafka/secrets \
+    --env 'KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://$CP_KAFKA_TCP_9092_BIND_IP:$CP_KAFKA_TCP_9092_BIND_PORT' \
+    --env 'KAFKA_ZOOKEEPER_CONNECT=$(curl -s -o /dev/null -w %{redirect_url} $SERVICE_LOCATOR/zookeeper | sed s@^tcp://@@)'
+```
+
+#### MySQL
+
+[MySQL](https://www.mysql.com/) is an open-source Relational Database Management System (RDBMS). The example below deploys the MySQL team's image to your ConductR cluster. For more information on this image and its arguments, refer to [MySQL](https://hub.docker.com/_/mysql/) on Docker Hub.
+ 
+ ```bash
+conduct load mysql:5.7 \
+    --endpoint mysql-tcp-3306 \
+        --service-name mysql \
+        --bind-port 3306 \
+    --volume mysql-data=/var/lib/mysql \
+    --env MYSQL_ROOT_PASSWORD=my-secret-pw
+ ```
+
+#### PostgreSQL
+
+[PostgreSQL](https://www.postgresql.org/) is an open-source Relational Database Management System (RDBMS). The example below deploys the PostgreSQL community's image into your ConductR cluster. For more information on this image and its arguments, refer to [PostgreSQL](https://hub.docker.com/_/postgres/) on Docker Hub.
+
+```bash
+conduct load postgres:9.6.3 \
+    --endpoint postgres-tcp-5432 \
+        --service-name postgres \
+        --bind-port 5432 \
+    --volume postgres-data=/var/lib/postgresql/data \
+    --env POSTGRES_PASSWORD=mysecretpassword
+```
+
+#### ZooKeeper
+
+[ZooKeeper](https://zookeeper.apache.org/) is a distributed coordination service. The example below deploys [Confluent, Inc](https://www.confluent.io/)'s ZooKeeper image into your ConductR cluster. For more information on this image and its arguments, refer to [Confluent's Documentation](http://docs.confluent.io/current/cp-docker-images/docs/quickstart.html#zookeeper).
+ 
+ ```bash
+conduct load confluentinc/cp-zookeeper \
+    --endpoint cp-zookeeper-tcp-2181 \
+        --service-name zookeeper \
+        --bind-port 0 \
+    --volume zookeeper-data=/var/lib/zookeeper/data \
+    --volume zookeeper-secrets=/etc/zookeeper/secrets \
+    --volume zookeeper-log=/var/lib/zookeeper/log \
+    --env 'ZOOKEEPER_CLIENT_PORT=$CP_ZOOKEEPER_TCP_2181_BIND_PORT'
+ ```

--- a/src/main/play-doc/operation/ThirdPartyServices.md
+++ b/src/main/play-doc/operation/ThirdPartyServices.md
@@ -2,7 +2,9 @@
 
 ConductR's method of delivering third-party service support embraces the [Open Container Initiative](https://www.opencontainers.org/) specifications. A vendor simply needs to provide a Docker or OCI image and ConductR can then take care of deploying and scaling it across your cluster.
 
-We've spent a lot of effort ensuring that essential services will work correctly in a ConductR cluster. Below, you'll find a curated list of common applications and the required arguments to load them into your cluster.
+We've spent a lot of effort ensuring that essential services will work correctly in a ConductR cluster. Below, you'll find a curated list of common applications and the required arguments to load them into your cluster. This is especially useful for getting started quickly during development as installing these services is often not trivial.
+
+Note that operating these services in production requires a lot of domain-specific knowledge. As such, we recommend you weigh the benefits of managing them yourself with ConductR versus using a hosted solution in combination with ConductR's [external service support](ExternalServices).  
 
 * [Elasticsearch](#Elasticsearch)
 * [Kafka](#Kafka)

--- a/src/main/play-doc/operation/index.toc
+++ b/src/main/play-doc/operation/index.toc
@@ -13,5 +13,6 @@ DynamicProxyConfiguration:Dynamic proxy configuration
 LogFiles:Log Files
 BundleHousekeeping:Bundle Housekeeping
 ContinuousDeliverySetupOps: Continuous Delivery Setup
+ThirdPartyServices:Third-Party Services
 ExternalServices:External Service Discovery
 ConfigurationRef:Configuration Reference


### PR DESCRIPTION
This PR adjusts the doc for the following:

* Page on running external services using official docker images added
* `bndl` instead of `shazar`
* `conduct load` arguments for dynamically creating configuration via `--env` and other arguments
* Modifying bundles with `bndl`
* Various OCI mentions throughout, plus information on its implementation and operation
* De-prioritize the position of creating OCI bundles - fixes #385 