### PR TITLE
2.1 Fixes

### DIFF
--- a/src/main/play-doc/operation/ClusterConfiguration.md
+++ b/src/main/play-doc/operation/ClusterConfiguration.md
@@ -31,7 +31,7 @@ The ConductR Core service must be restarted after changes to the `conductr.ini` 
 
 The configuration file `/usr/share/conductr-agent/conf/conductr-agent.ini` is the primary configuration file for the ConductR Agent service. This file is used to specify ConductR Agent settings, such as `-Dconductr.agent.roles` used during installation. See the comments section of the `conductr-agent.ini` file for more examples.
 
-Akka module configuration can also be set using this file. For example, to assign a ConductR node the roles of `megaIOPS` and `muchMem` instead of the default, `web`, set `akka.cluster.roles` in `conductr-agent.ini`:
+Akka module configuration can also be set using this file. For example, to assign a ConductR node the roles of `megaIOPS` and `muchMem` instead of the default, `web`, set `conductr.agent.roles` in `conductr-agent.ini`:
 
 ```bash
 echo -Dconductr.agent.roles.0=megaIOPS | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini

--- a/src/main/play-doc/operation/Install.md
+++ b/src/main/play-doc/operation/Install.md
@@ -582,6 +582,7 @@ SG-AGENT-PRIVATE Inbound Rules
 | :------ | :-----  | :---------- | :-------------- | :-------------------------------------------- |
 | SSH     | TCP     | 22          | SG-BASTION      | Remote SSH Access                             |
 | Custom  | TCP     | 2552        | SG-CORE         | Akka Remoting from Core to Agent              |
+| HTTP    | TCP     | 10000-10999 | SG-CORE         | Proxy access from Core to Agent               |
 | HTTP    | TCP     | 10000-10999 | SG-AGENT-PUBLIC | Proxy access from ConductR public agent nodes |
 
 


### PR DESCRIPTION
Add core node access to 10K port range in private agent.
Correct role configuration #393 