### PR TITLE
Move mesos port range

### DIFF
--- a/src/main/play-doc/operation/ConfigurationRef.md
+++ b/src/main/play-doc/operation/ConfigurationRef.md
@@ -1039,8 +1039,8 @@ conductr {
           # Port range reserved for exposing endpoints for running bundles within ConductR.
           # ConductrR agent's port allocator settings will be configured based on this port range.
           allocated-ports = {
-            start = 10000
-            end = 10999
+            start = 11000
+            end = 11999
           }
 
           # Ports opened by the Agents to proxy requests from its Bundles to ConductR Core services, i.e.


### PR DESCRIPTION
Mesos port range is now moved from `11000` to `11999` to match changes in ConductR