### PR TITLE
Add Licensing information to operations guide

### DIFF
--- a/src/main/play-doc/operation/Licensing.md
+++ b/src/main/play-doc/operation/Licensing.md
@@ -69,7 +69,7 @@ When you issue `conduct info` you will see the same license details that were re
 
 ### Updating your License
 
-If you need to update the license on an already licensed cluster you can do so using the `--force` command switch. This is useful when you want to change the license to a different user or when your license is close to expiring.  Enter `conduct load-license --offline` and the command line and then follow the prompts to load a new license.
+If you need to update the license on an already licensed cluster you can do so using the `--force` command switch. This is useful when you want to change the license to a different user or when your license is close to expiring.  Enter `conduct load-license --force` and the command line and then follow the prompts to load a new license.
 
 ## Automate Licensing at Startup
 

--- a/src/main/play-doc/operation/Licensing.md
+++ b/src/main/play-doc/operation/Licensing.md
@@ -1,10 +1,8 @@
 # Licensing
 
-It is required to load a license into your ConductR cluster if you want to be able to use more than one ConductR agent. 
-To license the cluster you must use the ConductR CLI `conduct load-license` command.
+It is required to load a license into your ConductR cluster if you want to be able to use more than one ConductR agent. To license the cluster you must use the ConductR CLI `conduct load-license` command.
 
-The license will only need to be loaded once for as long as the cluster is up, or until the license expires.  Anyone 
-using the CLI to work with an already licensed cluster will be use the same license. 
+The license will only need to be loaded once for as long as the cluster is up, or until the license expires.  Anyone using the CLI to work with an already licensed cluster will be use the same license. 
 
 ## Loading the License
 
@@ -21,8 +19,7 @@ Steps to load the license.
 ```
 $ conduct load-license
 
-An access token is required. Please visit https://www.lightbend.com/platform/enterprise-suite/access-token to 
-obtain one for free or for your commercial licenses.
+An access token is required. Please visit https://www.lightbend.com/platform/enterprise-suite/access-token to obtain one for free or for your commercial licenses.
 
 Please enter your access token: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -39,23 +36,17 @@ License successfully loaded
 If successful you will see the following.
 
 - A message indicating the license was added to the ConductR cluster.
-- A summary of license information, including your user token.  This will match your bintray credentials in your 
-`~/.lightbend/commercial.properties` file.
+- A summary of license information, including your user token.  This will match your bintray credentials in your `~/.lightbend/commercial.properties` file.
 - A date when the license expires and you will need to execute `load-license` again.
 - Components of Enterprise Suite that your license is authorized for.
 
 ### Offline Mode
 
-In privileged environments, loading the license is straightforward.  In environments that cannot access the internet you 
-must install the license in offline mode (i.e. from your CLI without having an HTTP proxy setup, or if you’re 
-installing the CLI on a server with no internet access).
+In privileged environments, loading the license is straightforward.  In environments that cannot access the internet you must install the license in offline mode (i.e. from your CLI without having an HTTP proxy setup, or if you’re installing the CLI on a server with no internet access).
 
 Steps to install the license in offline mode.
 
-1. Login to your lightbend.com account with your licensed email and setup your `~/.lightbend/commercial.credentials` 
-as described on [lightbend.com](https://www.lightbend.com/product/conductr/developer).  While setting up your 
-`commercial.credentials` it’s important to use the email associated with your organization's license, and not a personal
-account.  In enterprise environments your license would usually be associated with your corporate email.
+1. Login to your lightbend.com account with your licensed email and setup your `~/.lightbend/commercial.credentials` as described on [lightbend.com](https://www.lightbend.com/product/conductr/developer).  While setting up your `commercial.credentials` it’s important to use the email associated with your organization's license, and not a personal account.  In enterprise environments your license would usually be associated with your corporate email.
 2. Retrieve your license information from https://www.lightbend.com/product/conductr/license
 3. Copy & paste the license into your `~/.lightbend/license` file.
 4. Execute `conduct load-license --offline` at the command line.
@@ -74,30 +65,20 @@ License successfully loaded
 
 ### Viewing the current license ConductR cluster
 
-When you issue `conduct info` you will see the same license details that were returned when the license was first
-loaded.
+When you issue `conduct info` you will see the same license details that were returned when the license was first loaded.
 
 ### Updating your License
 
-If you need to update the license on an already licensed cluster you can do so using the `--force` command switch. This
-is useful when you want to change the license to a different user or when your license is close to expiring.  Enter
-`conduct load-license --offline` and the command line and then follow the prompts to load a new license.
+If you need to update the license on an already licensed cluster you can do so using the `--force` command switch. This is useful when you want to change the license to a different user or when your license is close to expiring.  Enter `conduct load-license --offline` and the command line and then follow the prompts to load a new license.
 
 ## Automate Licensing at Startup
 
-When a license is loaded it is submitted to the ConductR cluster and distributed to all the ConductR core nodes.  The
-license resides in memory, so in the event of a complete cluster shutdown the data is lost.  In production this would
-be an unlikely scenario as your cluster should be able to tolerate the failure of some nodes.  As long as one node in
-your cluster remains online your license will be intact.
+When a license is loaded it is submitted to the ConductR cluster and distributed to all the ConductR core nodes.  The license resides in memory, so in the event of a complete cluster shutdown the data is lost.  In production this would be an unlikely scenario as your cluster should be able to tolerate the failure of some nodes.  As long as one node in your cluster remains online your license will be intact.
 
-In non-production environments it may be commonplace to shutdown whole clusters for a number of reasons: the cluster is 
-no longer required, to save on public cloud instance charges, etc.
+In non-production environments it may be commonplace to shutdown whole clusters for a number of reasons: the cluster is no longer required, to save on public cloud instance charges, etc.
 
-When a cluster starts up in any environment it is important to license it before app bundles are loaded and run again.
-By retrieving your license manually as described in "Offline Mode", you can automate the licensing of a cluster whenever
-it's first started up.
+When a cluster starts up in any environment it is important to license it before app bundles are loaded and run again. By retrieving your license manually as described in "Offline Mode", you can automate the licensing of a cluster whenever it's first started up.
 
-Remember that licenses expire, so set a reminder to occassionally retrieve an updated `./.conductr/license` file for 
-your deployment script.
+Remember that licenses expire, so set a reminder to occassionally retrieve an updated `./.conductr/license` file for your deployment script.
 
 In future versions of ConductR the license may be persisted to disk.

--- a/src/main/play-doc/operation/Licensing.md
+++ b/src/main/play-doc/operation/Licensing.md
@@ -79,6 +79,6 @@ In non-production environments it may be commonplace to shutdown whole clusters 
 
 When a cluster starts up in any environment it is important to license it before app bundles are loaded and run again. By retrieving your license manually as described in "Offline Mode", you can automate the licensing of a cluster whenever it's first started up.
 
-Remember that licenses expire, so set a reminder to occassionally retrieve an updated `./.conductr/license` file for your deployment script.
+Remember that licenses expire, so set a reminder to occassionally retrieve an updated `./.conductr/license` file for your deployment script.  An existing ConductR cluster and its running bundles will continue to run when the license expires.  New agents, or agents that try to rejoin after a failure, will not be able to join the cluster.
 
 In future versions of ConductR the license may be persisted to disk.

--- a/src/main/play-doc/operation/Licensing.md
+++ b/src/main/play-doc/operation/Licensing.md
@@ -1,0 +1,107 @@
+# Licensing
+
+It is required to load a license into your ConductR cluster if you want to be able to use more than one ConductR agent. 
+To license the cluster you must use the ConductR CLI `conduct load-license` command.
+
+The license will only needed to be loaded once for as long as the cluster is up, or until the license expires.  
+
+## Loading the License
+
+### Online Mode
+
+The standard workflow assumes that the workstation you are running the CLI on has connectivity to the internet.  To load
+the license 
+
+1. Execute `conduct load-license` at the command line.
+2. Retrieve your Enterprise Suite access token from https://www.lightbend.com/platform/enterprise-suite/access-token
+3. Enter your access token when prompted
+
+```
+$ conduct load-license
+
+An access token is required. Please visit https://www.lightbend.com/platform/enterprise-suite/access-token to 
+obtain one for free or for your commercial licenses.
+
+Please enter your access token: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Loading license into ConductR at 192.168.10.1
+
+Licensed To: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+Expires In: 365 days (Fri 27 Jul 2018 16:09PM)
+Grants: akka-sbr, cinnamon, conductr, fortify
+
+License successfully loaded
+```
+
+If successful you will see the following
+- A message indicating the license was added to the ConductR cluster.
+- A summary of license information, including your user token.  This will match your bintray credentials in your 
+`~/.lightbend/commercial.properties` file.
+- A date when the license expires and you will need to execute `load-license` again.
+- Components of Enterprise Suite that your license is authorized for.
+
+### Offline Mode
+
+In privileged environments, loading the license is straightforward.  In environments that cannot access the internet you 
+must install the license in offline mode (i.e. from your CLI without having the HTTP proxy setup, or if you’re 
+installing the CLI on a server with no internet access).
+
+Steps to install the license in offline mode.
+
+1. Login to your lightbend.com account with your licensed email and setup your `~/.lightbend/commercial.credentials` 
+as described on [lightbend.com](https://www.lightbend.com/product/conductr/developer).  While setting up your 
+`commercial.credentials` it’s important to use the email associated with your organization's license, and not a personal
+account.  If enterprise environments this is usually your corporate email.
+2. Download your `license` file manually.  You can find your license by visiting 
+https://www.lightbend.com/product/conductr/license
+3. Copy & paste the contents of this page into your `~/.lightbend/license` file.
+4. Execute `conduct load-license --offline` at the command line.
+
+```
+$ conduct load-license --offline
+Skipping downloading license from Lightbend.com
+Loading license into ConductR at 192.168.10.1
+
+Licensed To: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+Expires In: 365 days (Fri 27 Jul 2018 16:09PM)
+Grants: akka-sbr, cinnamon, conductr, fortify
+
+License successfully loaded
+```
+
+### Viewing the current license ConductR cluster
+
+When you issue `conduct info` you will see the same license details that were returned when the license was first
+loaded.
+
+### Updating your License
+
+If you need to update the license on an already licensed cluster you can do so using the `--force` command switch. This
+is useful when you want to change the license to a different user or when your license is close to expiring.  Enter
+`conduct load-license --offline` and the command line and then follow the prompts to load a new license.
+
+## Automate Licensing at Startup
+
+When a license is loaded it is submitted to the ConductR cluster and distributed to all the ConductR core nodes.  The
+license resides in memory, so in the event of a complete cluster shutdown the data is lost.  In production this would
+be an unlikely scenario as your cluster should be able to tolerate the failure of some nodes.
+
+In non-production environments it may be commonplace to shutdown whole clusters for a number of reasons: cluster is no
+longer required, to save on public cloud instance charges, etc.
+
+In any environment, whenever a cluster starts up it is important to license before bundles are loaded and run again.
+By retrieving your license manually as described in "Offline Mode", you can automate the licensing of a cluster whenever
+it's first started up.
+
+Remember that licenses expire, so set a reminder to occassionally retrieve an updated `./.conductr/license` file for 
+your deployment script.
+
+## Other ConductR Licensing Information and Caveats
+
+- Anyone using the CLI to work with a licensed cluster will be using the same license.
+- Bundles, like licenses, are lost in the event of a total cluster shutdown.  You should plan for this contingency 
+when starting your cluster in the same manner you plan to license it.  You should load all required support bundles
+(`visualizer`, `haproxy`, `continuous-delivery`, etc.) as well as your latest running app bundles.
+- While there is at least one node of the cluster up, the license will be intact.
+- Future versions of ConductR will persist the license to disk in the cluster.

--- a/src/main/play-doc/operation/Licensing.md
+++ b/src/main/play-doc/operation/Licensing.md
@@ -3,14 +3,16 @@
 It is required to load a license into your ConductR cluster if you want to be able to use more than one ConductR agent. 
 To license the cluster you must use the ConductR CLI `conduct load-license` command.
 
-The license will only needed to be loaded once for as long as the cluster is up, or until the license expires.  
+The license will only need to be loaded once for as long as the cluster is up, or until the license expires.  Anyone 
+using the CLI to work with an already licensed cluster will be use the same license. 
 
 ## Loading the License
 
 ### Online Mode
 
-The standard workflow assumes that the workstation you are running the CLI on has connectivity to the internet.  To load
-the license 
+The standard workflow assumes that the workstation you are running the ConductR CLI on has connectivity to the internet.
+
+Steps to load the license.
 
 1. Execute `conduct load-license` at the command line.
 2. Retrieve your Enterprise Suite access token from https://www.lightbend.com/platform/enterprise-suite/access-token
@@ -34,7 +36,8 @@ Grants: akka-sbr, cinnamon, conductr, fortify
 License successfully loaded
 ```
 
-If successful you will see the following
+If successful you will see the following.
+
 - A message indicating the license was added to the ConductR cluster.
 - A summary of license information, including your user token.  This will match your bintray credentials in your 
 `~/.lightbend/commercial.properties` file.
@@ -44,7 +47,7 @@ If successful you will see the following
 ### Offline Mode
 
 In privileged environments, loading the license is straightforward.  In environments that cannot access the internet you 
-must install the license in offline mode (i.e. from your CLI without having the HTTP proxy setup, or if you’re 
+must install the license in offline mode (i.e. from your CLI without having an HTTP proxy setup, or if you’re 
 installing the CLI on a server with no internet access).
 
 Steps to install the license in offline mode.
@@ -52,10 +55,9 @@ Steps to install the license in offline mode.
 1. Login to your lightbend.com account with your licensed email and setup your `~/.lightbend/commercial.credentials` 
 as described on [lightbend.com](https://www.lightbend.com/product/conductr/developer).  While setting up your 
 `commercial.credentials` it’s important to use the email associated with your organization's license, and not a personal
-account.  If enterprise environments this is usually your corporate email.
-2. Download your `license` file manually.  You can find your license by visiting 
-https://www.lightbend.com/product/conductr/license
-3. Copy & paste the contents of this page into your `~/.lightbend/license` file.
+account.  In enterprise environments your license would usually be associated with your corporate email.
+2. Retrieve your license information from https://www.lightbend.com/product/conductr/license
+3. Copy & paste the license into your `~/.lightbend/license` file.
 4. Execute `conduct load-license --offline` at the command line.
 
 ```
@@ -85,23 +87,17 @@ is useful when you want to change the license to a different user or when your l
 
 When a license is loaded it is submitted to the ConductR cluster and distributed to all the ConductR core nodes.  The
 license resides in memory, so in the event of a complete cluster shutdown the data is lost.  In production this would
-be an unlikely scenario as your cluster should be able to tolerate the failure of some nodes.
+be an unlikely scenario as your cluster should be able to tolerate the failure of some nodes.  As long as one node in
+your cluster remains online your license will be intact.
 
-In non-production environments it may be commonplace to shutdown whole clusters for a number of reasons: cluster is no
-longer required, to save on public cloud instance charges, etc.
+In non-production environments it may be commonplace to shutdown whole clusters for a number of reasons: the cluster is 
+no longer required, to save on public cloud instance charges, etc.
 
-In any environment, whenever a cluster starts up it is important to license before bundles are loaded and run again.
+When a cluster starts up in any environment it is important to license it before app bundles are loaded and run again.
 By retrieving your license manually as described in "Offline Mode", you can automate the licensing of a cluster whenever
 it's first started up.
 
 Remember that licenses expire, so set a reminder to occassionally retrieve an updated `./.conductr/license` file for 
 your deployment script.
 
-## Other ConductR Licensing Information and Caveats
-
-- Anyone using the CLI to work with a licensed cluster will be using the same license.
-- Bundles, like licenses, are lost in the event of a total cluster shutdown.  You should plan for this contingency 
-when starting your cluster in the same manner you plan to license it.  You should load all required support bundles
-(`visualizer`, `haproxy`, `continuous-delivery`, etc.) as well as your latest running app bundles.
-- While there is at least one node of the cluster up, the license will be intact.
-- Future versions of ConductR will persist the license to disk in the cluster.
+In future versions of ConductR the license may be persisted to disk.

--- a/src/main/play-doc/operation/index.toc
+++ b/src/main/play-doc/operation/index.toc
@@ -16,3 +16,4 @@ ContinuousDeliverySetupOps: Continuous Delivery Setup
 ThirdPartyServices:Third-Party Services
 ExternalServices:External Service Discovery
 ConfigurationRef:Configuration Reference
+Licensing:Licensing


### PR DESCRIPTION
Information on how to license the ConductR clusters.  Tips for different types of cluster environments.  Caveats of the licensing process.

I have not tested to see how this markdown looks rendered with play-doc.  Can someone point me to directions on how to use this documentation tool?