### PR TITLE
Refine DC/OS upgrade, restart, and stop procedure

### DIFF
--- a/src/main/play-doc/operation/ClusterRestart.md
+++ b/src/main/play-doc/operation/ClusterRestart.md
@@ -1,6 +1,7 @@
 # Restarting ConductR Cluster
 
-Restarting the entire ConductR cluster should only be considered in a face of disaster where all nodes have been lost. Choose one of the following sections depending on the ConductR mode:
+Restarting the entire ConductR cluster should only be considered in a face of disaster where all nodes have been lost. 
+Choose one of the following sections depending on the ConductR mode:
 
 * [Standalone mode](#Standalone-mode)
 * [DC/OS mode](#DC/OS-mode)
@@ -75,42 +76,28 @@ sudo service conductr-agent restart
 
 ## DC/OS mode
 
-> Do not Scale to 0, Suspend, or Destroy ConductR cluster directly from the Marathon UI without following the steps below. Doing so without following the steps below will cause the ConductR to be de-activated from DC/OS and forcefully detached from its still running tasks. These tasks will be orphaned and can't be terminated as it's no longer visible from DC/OS CLI's and Marathon's perspective.
+To restart the cluster in DC/OS mode, follow the steps below. You'll also want to follow these steps if you are deploying
+a configuration change. Note that upon cluster start, your bundles will need to be reloaded.
 
-* Retrieve the service id of the ConductR service:
+> Do not destroy the ConductR cluster directly from the UI without following the steps below.
 
-```bash
-dcos service
-NAME       HOST        ACTIVE  TASKS  CPU     MEM      DISK      ID
-conductr   10.0.1.118  True    0      11.8    42760.0  120804.0  my-conductr
-```
-
-* Shutdown the ConductR service by using the `dcos service shutdown`. The command shuts down all ConductR executors on the Mesos agents and with it all tasks and bundles that have been created by ConductR. On Mesos master, the service is also marked as removed:
-
-```bash
-dcos service shutdown my-conductr
-```
-
-* The ConductR framework instances are still running. Stop them by suspending the ConductR service via the DC/OS Services UI page:
+* Stop the ConductR service via the DC/OS Services UI page:
 
 ```
 http://dcos-host/#services >> Services >> conductr >> More >> Suspend >> Suspend Service
 ```
 
-* Once a service has been removed the id cannot be reused. Therefore, rename your service by editing the service configuration:
+* Wait for all of the related tasks in the DC/OS UI to stop. This takes a couple minutes. When complete, there will be
+  0 active tasks in the service group.
+
+* Once the service is indicated as Suspended, make any configuration changes if necessary.
 
 ```
-http://dcos-host/#services >> Services >> conductr >> Edit >> <Change ID> >> Deploy Changes
+http://dcos-host/#services >> Services >> conductr >> More >> Edit >> Review & Run >> Run Service
 ```
 
-* The previous step does not rename the existing service but instead create an additional service with the new id. Remove the old service:
+* Finally, start the service again, choosing an odd number of instances (3 recommended). This will start the ConductR framework instances and the executors on the Mesos agent:
 
 ```
-http://dcos-host/#services >> Services >> conductr >> More >> Destroy >> Destroy Service
-```
-
-* Navigate to the new service and start it. This will start the ConductR framework instances and the executors on the Mesos agent:
-
-```
-http://dcos-host/#services >> Services >> conductr >> Scale >> <Select number of ConductR framework instances> >> Scale Service
+http://dcos-host/#services >> Services >> conductr >> More >> Resume >> Resume Service
 ```

--- a/src/main/play-doc/operation/ClusterStop.md
+++ b/src/main/play-doc/operation/ClusterStop.md
@@ -45,38 +45,26 @@ sudo service conductr-agent stop
 
 ## DC/OS mode
 
-> Do not Scale to 0, Suspend, or Destroy ConductR cluster directly from the Marathon UI without following the steps below.
- Doing so without following the steps below will cause the ConductR to be de-activated from DC/OS and forcefully detached from its still running tasks.
- These tasks will be orphaned and can't be terminated as it's no longer visible from DC/OS CLI's and Marathon's perspective.
+> Do not destroy the ConductR cluster directly from the UI without following the steps below.
 
-* Retrieve the service id of the ConductR service:
-
-```bash
-dcos service
-NAME       HOST        ACTIVE  TASKS  CPU     MEM      DISK      ID
-conductr   10.0.1.118  True    0      11.8    42760.0  120804.0  my-conductr
-```
-
-* Shutdown the ConductR service by using the `dcos service shutdown`. The command shuts down all ConductR executors on the Mesos agents
- and with it all tasks and bundles that have been created by ConductR. On Mesos master, the service is also marked as removed:
-
-```bash
-dcos service shutdown my-conductr
-```
-
-* The ConductR framework instances are still running. Stop them by suspending the ConductR service via the DC/OS Services UI page:
+* Stop the ConductR service via the DC/OS Services UI page:
 
 ```
 http://dcos-host/#services >> Services >> conductr >> More >> Suspend >> Suspend Service
 ```
 
-* Destroy the service:
+* Wait for all of the related tasks in the DC/OS UI to stop. This takes a couple minutes. When complete, there will be
+  0 active tasks in the service group.
+
+* If reconfiguring, edit its JSON in the DC/OS UI and start the service again.
+
+* If uninstalling, destroy the service:
 
 ```
 http://dcos-host/#services >> Services >> conductr >> More >> Destroy >> Destroy Service
 ```
 
-* Remove framework resource reservations by running the framework cleaner:
+* If uninstalling, remove framework resource reservations by running the framework cleaner:
 
 ```bash
 docker run mesosphere/janitor /janitor.py -z dcos-service-conductr

--- a/src/main/play-doc/operation/ClusterUpgrade.md
+++ b/src/main/play-doc/operation/ClusterUpgrade.md
@@ -8,7 +8,13 @@ On a per-cluster basis, incoming requests are directed from the old cluster to t
 
 ## Per node upgrade
 
-Per node upgrades are generally easier. However, they can only be performed across ConductR patch releases, e.g. 2.0.0 to 2.0.1. Use the [per cluster upgrade](#Per-cluster-upgrade) approach to perform a ConductR upgrade to a minor or major version, e.g. 2.0.0 to 2.1.0.
+> *A note for DC/OS users:* If you're using ConductR on DC/OS, you must use 
+the [per cluster upgrade](#Per-cluster-upgrade) approach as Per node upgrades are not supported.
+
+Per node upgrades are generally easier. However, they can only be performed across ConductR patch releases, e.g. 2.0.0 to 2.0.1, and
+are only supported by stand-alone installations.
+Use the [per cluster upgrade](#Per-cluster-upgrade) approach if you are running on DC/OS, or to perform a ConductR 
+upgrade to a minor or major version, e.g. 2.0.0 to 2.1.0.
 
 To perform a per node upgrade for ConductR Core, introduce new cluster members to the cluster. The new nodes could be created with updated versions of ConductR, Java, the Linux operating system or any other component installed during provisioning. As old members are removed from the cluster, bundles will be replicated to the new resources.
 
@@ -24,7 +30,21 @@ Be certain to ensure that sufficient resources for all roles are provisioned. St
 
 ## Per cluster upgrade
 
-To perform a per cluster upgrade, build a new cluster in isolation from the current running cluster. Once the new cluster is fully prepared, cut-over traffic using DNS, load balancers, routers, etc. Per cluster, upgrades may require more complex strategies for migrating data storage managed by the cluster.
+To perform a per cluster upgrade, build a new cluster in isolation from the current running cluster. Once the 
+new cluster is fully prepared, cut-over traffic using DNS, load balancers, routers, etc. Per cluster, 
+upgrades may require more complex strategies for migrating data storage managed by the cluster.
+
+> *A note for DC/OS users:* If you're using ConductR on DC/OS, ensure that you obtain a new copy of the `marathon.json` file from 
+[Enterprise Suite DC/OS](https://www.lightbend.com/platform/enterprise-suite/dcos/Linux) page. To allow simultaneous
+installations of ConductR on DC/OS, the port ranges used by a given ConductR release are cycled through four different
+sets. Be sure to only upgrade up to 3 minor releases at a time (e.g. 2.1.6 to 2.1.9 is supported, but 2.1.6 to 2.1.10 is not), 
+and also take great care to remove your old cluster once it is no longer in use.
+
+Once you've built your new cluster, use the CLI's `conduct backup` and `conduct restore` functionality to restore your
+bundles. See our [[CLI|CLI]] documentation for more details.
+
+Once your new cluster is running and traffic has been directed to it, stop and remove your old cluster by following 
+the [[Cluster Stop|ClusterStop]] instructions.
 
 ## Elasticsearch Verification
 


### PR DESCRIPTION
This PR refines the documentation for operating DC/OS -- specifically, how to upgrade, stop, and restart the service.