### PR TITLE
Update docs for ConductR 2.10 (supporting DC/OS 1.10)

### DIFF
--- a/src/main/play-doc/general/ReleaseNotes.md
+++ b/src/main/play-doc/general/ReleaseNotes.md
@@ -47,6 +47,12 @@ The notion of metadata with containers is quite popular noting that bundles also
 
 The contents of annotations are generally outside of the scope of what ConductR itself is concerned with.
 
+## 2.1.10 - Wednesday, October 11th, 2017
+* Fixed a bug causing DC/OS executor arguments with white space to break
+* Added a setting, `conductr.control-server.log-all-requests`, to log all control protocol requests to the debug log
+* DC/OS executor no longer exits on startup if there is an issue configuring CGroups
+* Fixed another cosmetic issue within conductr-haproxy when it published its telemetry.
+
 ## 2.1.9 - Wednesday September 13th, 2017
 * The DC/OS agent script now ensures it has access to individual cgroup files before writing to them. This previously caused an issue when installing 2.1.7 and 2.1.8 on DC/OS.
 

--- a/src/main/play-doc/operation/ClusterStop.md
+++ b/src/main/play-doc/operation/ClusterStop.md
@@ -60,8 +60,25 @@ http://dcos-host/#services >> Services >> conductr >> More >> Suspend >> Suspend
 
 * If uninstalling, destroy the service:
 
+#### DC/OS 1.8, 1.9
+
 ```
 http://dcos-host/#services >> Services >> conductr >> More >> Destroy >> Destroy Service
+```
+
+#### DC/OS 1.10
+
+Starting with DC/OS 1.10, you must use the `dcos marathon app list` and `dcos marathon app remove` commands to
+uninstall ConductR.
+
+```
+# Use dcos marathon app list to find the framework ID
+dcos marathon app list
+ID               MEM   CPUS  TASKS  HEALTH  DEPLOYMENT  WAITING  CONTAINER  CMD
+/conductr-2.1.9  1024   1     1/1    1/1       ---      False       N/A     GLOBIGNORE='*.tar.gz:*.tgz';...
+
+# Use dcos marathon app remove to remove ConductR
+dcos marathon app remove /conductr-2.1.9
 ```
 
 * If uninstalling, remove framework resource reservations by running the framework cleaner:


### PR DESCRIPTION
* Adds entry to release notes
* Adds blurb on uninstalling on DC/OS 1.10